### PR TITLE
⚡ Optimize script loading by moving to head with defer

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,16 @@
   <!-- Custom styles for this template -->
   <link href="css/resume.min.css" rel="stylesheet">
 
+  <!-- Bootstrap core JavaScript from CDNs -->
+  <script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+  <script defer src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
+
+  <!-- Plugin JavaScript -->
+  <script defer src="vendor/jquery-easing/jquery.easing.min.js"></script>
+
+  <!-- Custom scripts for this template -->
+  <script defer src="js/resume.min.js"></script>
+
 </head>
 
 <body id="page-top">
@@ -1233,16 +1243,6 @@
     <!-- TODO Obviously, i'll need a contact form. And I would like to put some CTA throughout the page to get to this contact form -->
 
   </div>
-
-  <!-- Bootstrap core JavaScript from CDNs -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
-
-  <!-- Plugin JavaScript -->
-  <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
-
-  <!-- Custom scripts for this template -->
-  <script src="js/resume.min.js"></script>
 
 </body>
 


### PR DESCRIPTION
💡 **What:** Moved 4 render-blocking scripts (`jquery`, `bootstrap`, `jquery-easing`, `resume.js`) from the end of the `<body>` to the `<head>` and added the `defer` attribute.

🎯 **Why:** This allows the browser to download scripts in parallel while parsing the HTML, rather than blocking rendering until the scripts are downloaded and executed. This improves the perceived load time and Time to Interactive.

📊 **Measured Improvement:** Verified that scripts are now loaded with `defer` in the `<head>`. A Playwright script confirmed that the page remains interactive (e.g., navigation links work) and no console errors were introduced. Exact performance metrics (ms) were not gathered due to the simulated environment, but this is a standard best practice for critical path optimization.

---
*PR created automatically by Jules for task [16376354304158919299](https://jules.google.com/task/16376354304158919299) started by @VBSylvain*