### PR TITLE
Shield: Add rel='noopener noreferrer' to external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,16 +150,16 @@
           Afficher ou masquer
         </a>
         <div class="social-icons mt-5">
-          <a target="_blank" href="https://www.linkedin.com/in/vbsylvain/" title="LinkedIn">
+          <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/vbsylvain/" title="LinkedIn">
             <i class="fab fa-linkedin-in"></i>
           </a>
-          <a target="_blank" href="https://github.com/VBSylvain" title="GitHub">
+          <a target="_blank" rel="noopener noreferrer" href="https://github.com/VBSylvain" title="GitHub">
             <i class="fab fa-github"></i>
           </a>
-          <a target="_blank" href="https://www.meetup.com/fr-FR/members/299830849/" title="MeetUp">
+          <a target="_blank" rel="noopener noreferrer" href="https://www.meetup.com/fr-FR/members/299830849/" title="MeetUp">
             <i class="fab fa-meetup"></i>
           </a>
-          <a target="_blank" href="https://www.malt.fr/profile/sylvainvizzinibruyas" title="Malt">
+          <a target="_blank" rel="noopener noreferrer" href="https://www.malt.fr/profile/sylvainvizzinibruyas" title="Malt">
             <i class="fas fa-asterisk"></i>
           </a>
         </div>
@@ -452,7 +452,7 @@
                 </li>
                 <li>
                   <i class="far fa-check-circle"></i>
-                  Accompagnement du <a target="_blank" href="https://remy.ovh/" title="Rem42, développeur Symfony">développeur</a>
+                  Accompagnement du <a target="_blank" rel="noopener noreferrer" href="https://remy.ovh/" title="Rem42, développeur Symfony">développeur</a>
                 </li>
                 <li>
                   <i class="far fa-check-circle"></i>
@@ -527,11 +527,11 @@
                 </li>
                 <li>
                   <i class="far fa-check-circle"></i>
-                  Avant-vente - accompagnement de la force de vente auprès des prospects et clients. Notamment sur l’outil <a target="_blank" href="https://www.odoo.com" title="Odoo">Odoo</a>
+                  Avant-vente - accompagnement de la force de vente auprès des prospects et clients. Notamment sur l’outil <a target="_blank" rel="noopener noreferrer" href="https://www.odoo.com" title="Odoo">Odoo</a>
                 </li>
                 <li>
                   <i class="far fa-check-circle"></i>
-                  Gestion de projet de mise en place et d'adaptation du CRM <a target="_blank" href="https://www.sugarcrm.com">SugarCRM</a> et de ses forks :
+                  Gestion de projet de mise en place et d'adaptation du CRM <a target="_blank" rel="noopener noreferrer" href="https://www.sugarcrm.com">SugarCRM</a> et de ses forks :
                   <ul class="mb-0">
                     <li>
                       Recueil et définition du besoin
@@ -980,15 +980,15 @@
         <ul class="fa-ul mb-0">
           <li>
             <i class="fa-li fa fa-trophy text-warning"></i>
-            SCRUM Professional Product Owner - <a target="_blank" href="https://www.scrum.org/certificates/500059" title="Lien de vérification du certificat de Product Owner">Vers le certificat</a>
+            SCRUM Professional Product Owner - <a target="_blank" rel="noopener noreferrer" href="https://www.scrum.org/certificates/500059" title="Lien de vérification du certificat de Product Owner">Vers le certificat</a>
           </li>
           <li>
             <i class="fa-li fa fa-trophy text-warning"></i>
-            Professional SCRUM Master - <a target="_blank" href="https://www.scrum.org/certificates/513509" title="Lien de vérification du certificat de Scrum Master">Vers le certificat</a>
+            Professional SCRUM Master - <a target="_blank" rel="noopener noreferrer" href="https://www.scrum.org/certificates/513509" title="Lien de vérification du certificat de Scrum Master">Vers le certificat</a>
           </li>
           <li>
             <i class="fa-li fa fa-trophy text-warning"></i>
-            Make foundation - <a target="_blank" href="https://www.credly.com/badges/df7cc5f1-77f0-4389-9017-c2b7372ad844/public_url" title="Lien de vérification du certificat Make Foundation">Vers le certificat</a>
+            Make foundation - <a target="_blank" rel="noopener noreferrer" href="https://www.credly.com/badges/df7cc5f1-77f0-4389-9017-c2b7372ad844/public_url" title="Lien de vérification du certificat Make Foundation">Vers le certificat</a>
           </li>
           <li>
             <i class="fa-li fa fa-trophy text-warning"></i>


### PR DESCRIPTION
Added rel='noopener noreferrer' to all target='_blank' links in index.html to prevent Reverse Tabnabbing attacks. This mitigates the risk of the opened page gaining access to the window.opener object and potentially redirecting the user to a malicious site. Confirmed the fix with a verification script.

---
*PR created automatically by Jules for task [11759784686458868506](https://jules.google.com/task/11759784686458868506) started by @VBSylvain*