### PR TITLE
Sentinel: Add Subresource Integrity (SRI) to CDN links

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   <link rel="icon" type="image/JPG" href="img/profile2023.jpg">
 
   <!-- Bootstrap core CSS from CDN -->
-  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
   <!-- Custom fonts for this template -->
   <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet">
@@ -1235,8 +1235,8 @@
   </div>
 
   <!-- Bootstrap core JavaScript from CDNs -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js" integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm" crossorigin="anonymous"></script>
 
   <!-- Plugin JavaScript -->
   <script src="vendor/jquery-easing/jquery.easing.min.js"></script>

--- a/tests/verify_sri.py
+++ b/tests/verify_sri.py
@@ -1,0 +1,66 @@
+import hashlib
+import urllib.request
+from html.parser import HTMLParser
+import sys
+import base64
+
+def base64_encode(data):
+    return base64.b64encode(data).decode('utf-8')
+
+class SRIParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.issues = []
+
+    def handle_starttag(self, tag, attrs):
+        attr_dict = dict(attrs)
+        url = None
+        integrity = attr_dict.get('integrity')
+        crossorigin = attr_dict.get('crossorigin')
+
+        if tag == 'link' and 'stylesheet' in attr_dict.get('rel', ''):
+            url = attr_dict.get('href')
+        elif tag == 'script':
+            url = attr_dict.get('src')
+
+        if url and ('stackpath.bootstrapcdn.com' in url or 'ajax.googleapis.com' in url):
+            print(f"Checking {url}...")
+
+            # Fetch content
+            try:
+                with urllib.request.urlopen(url) as response:
+                    content = response.read()
+                    sha384_hash = hashlib.sha384(content).digest()
+                    expected_hash = "sha384-" + base64_encode(sha384_hash)
+
+                    if not integrity:
+                        self.issues.append(f"Missing integrity attribute for {url}. Expected: {expected_hash}")
+                    elif integrity != expected_hash:
+                        self.issues.append(f"Incorrect integrity hash for {url}. Found: {integrity}, Expected: {expected_hash}")
+
+                    if not crossorigin:
+                         self.issues.append(f"Missing crossorigin attribute for {url}. Expected: anonymous")
+                    elif crossorigin != "anonymous":
+                         self.issues.append(f"Incorrect crossorigin attribute for {url}. Found: {crossorigin}, Expected: anonymous")
+
+            except Exception as e:
+                self.issues.append(f"Error fetching {url}: {e}")
+
+if __name__ == "__main__":
+    parser = SRIParser()
+    try:
+        with open('index.html', 'r') as f:
+            content = f.read()
+            parser.feed(content)
+    except FileNotFoundError:
+        print("Error: index.html not found.")
+        sys.exit(1)
+
+    if parser.issues:
+        print("\nSRI Verification Failed:")
+        for issue in parser.issues:
+            print(f"- {issue}")
+        sys.exit(1)
+    else:
+        print("\nSRI Verification Passed!")
+        sys.exit(0)


### PR DESCRIPTION
Added integrity and crossorigin attributes to Bootstrap and jQuery CDN links in index.html to prevent malicious code injection.
Added verification script tests/verify_sri.py to ensure SRI hashes are correct.

---
*PR created automatically by Jules for task [10593598098539500851](https://jules.google.com/task/10593598098539500851) started by @VBSylvain*