### PR TITLE
🛡️ Sentinel: [MEDIUM] Add SRI hashes to CDN resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   <link rel="icon" type="image/JPG" href="img/profile2023.jpg">
 
   <!-- Bootstrap core CSS from CDN -->
-  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
   <!-- Custom fonts for this template -->
   <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet">
@@ -1235,8 +1235,8 @@
   </div>
 
   <!-- Bootstrap core JavaScript from CDNs -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js" integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm" crossorigin="anonymous"></script>
 
   <!-- Plugin JavaScript -->
   <script src="vendor/jquery-easing/jquery.easing.min.js"></script>


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Missing Subresource Integrity (SRI) hashes on external CDN resources. This makes the application vulnerable if the CDN is compromised and the served files are altered to include malicious code.
**🎯 Impact:** A compromised CDN could inject arbitrary JavaScript or CSS into the page, leading to XSS or styling redressing attacks on all users visiting the site.
**🔧 Fix:** Added the `integrity` attribute containing the SHA-384 hash of the file and `crossorigin="anonymous"` to the Bootstrap CSS, jQuery, and Bootstrap JS `<link>` and `<script>` tags in `index.html`.
**✅ Verification:**
1. Loaded `index.html` locally using Playwright to ensure all styles and scripts continue to function correctly (no visual regressions).
2. Parsed `index.html` with a Python script to verify the exact hashes are present on the tags.

---
*PR created automatically by Jules for task [18047589242914682583](https://jules.google.com/task/18047589242914682583) started by @VBSylvain*