### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,9 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Prevent reverse tabnabbing via noopener noreferrer -->
+            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +258,9 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Prevent reverse tabnabbing via noopener noreferrer -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Links opening in a new tab (`target="_blank"`) without `rel="noopener noreferrer"` can expose the `window.opener` object to the newly opened page. This is known as reverse tabnabbing and allows the malicious destination site to redirect the original page or execute unauthorized actions.
🎯 Impact: A compromised or untrusted external site (such as Malt or LinkedIn if URLs were hijacked or redirected) could manipulate the original portfolio page.
🔧 Fix: Appended `rel="noopener noreferrer"` to all `<a>` elements dynamically generated in `js/app.js` with `target="_blank"`.
✅ Verification: Tested locally via Python script verifying all `target="_blank"` attributes are now accompanied by the `rel="noopener noreferrer"` safety attributes.

---
*PR created automatically by Jules for task [8596281208562449865](https://jules.google.com/task/8596281208562449865) started by @VBSylvain*