### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent reverse tabnabbing on external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Reverse Tabnabbing (Missing `rel="noopener noreferrer"` on `target="_blank"` links).
🎯 **Impact:** When a user clicks an external link (like LinkedIn or Malt), the newly opened malicious or compromised site could access the original window's `window.opener` object, potentially redirecting the original page to a phishing site.
🔧 **Fix:** Added `rel="noopener noreferrer"` attributes to all 4 external link anchor tags in `js/app.js` to sever the connection between the original and new tabs.
✅ **Verification:** A Python verification script was run to ensure that the number of `target="_blank"` occurrences exactly matches the number of `rel="noopener noreferrer"` occurrences (4). Manual inspection confirms the changes.

---
*PR created automatically by Jules for task [16613675847676980121](https://jules.google.com/task/16613675847676980121) started by @VBSylvain*