### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Reverse Tabnabbing. Links that use `target="_blank"` without `rel="noopener noreferrer"` allow the newly opened tab to access the original window's `window.opener` object. This can be exploited to redirect the original page to a malicious site.
🎯 **Impact:** If external links (e.g., LinkedIn, Malt profiles) are compromised or redirect to malicious sites, an attacker could hijack the application's navigation context, leading to phishing or unauthorized actions.
🔧 **Fix:** Appended `rel="noopener noreferrer"` to all `<a>` tags in `js/app.js` that utilize `target="_blank"`.
✅ **Verification:** Verified all occurrences via regex and bash standard tools (`grep`) to ensure 100% coverage. No functionality was modified.

---
*PR created automatically by Jules for task [13148293615097672776](https://jules.google.com/task/13148293615097672776) started by @VBSylvain*