### PR TITLE
🛡️ Sentinel: Add rel="noopener noreferrer" to external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${identity.contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${identity.contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** External links opened via `target="_blank"` without the `rel="noopener noreferrer"` attribute allow the newly opened tab to retain a reference to the original window object via `window.opener`. This exposes the original page to reverse tabnabbing attacks, where the malicious site can redirect the original tab to a phishing page.
🎯 **Impact:** Potential phishing attack. A malicious actor could gain control of the user's original tab, presenting a fake login screen or other deceptive content to steal credentials or sensitive information.
🔧 **Fix:** Added `rel="noopener noreferrer"` to the LinkedIn and Malt anchor tags in `js/app.js` whenever `target="_blank"` is used.
✅ **Verification:** A programmatic Python script successfully asserted that all `target="_blank"` anchor tags in `js/app.js` now contain the secure `rel="noopener noreferrer"` attribute.

---
*PR created automatically by Jules for task [4237911398235617438](https://jules.google.com/task/4237911398235617438) started by @VBSylvain*