### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing Vulnerability

**Security Context**
This PR fixes a medium-severity vulnerability known as reverse tabnabbing. External links using `target="_blank"` without `rel="noopener noreferrer"` expose the `window.opener` object to the newly opened page. A malicious or compromised external site could exploit this to redirect the original page to a phishing site or execute malicious scripts in the context of the original tab.

**Changes**
* Added `rel="noopener noreferrer"` to all four instances of `target="_blank"` anchor tags generated in `js/app.js` (specifically within `renderHero` and `renderContact` functions).

**Verification**
* Verified via Python script leveraging regex that all anchor elements containing `target="_blank"` now also contain the required `rel="noopener noreferrer"` attributes. Code review complete.

---
*PR created automatically by Jules for task [6628156106378498428](https://jules.google.com/task/6628156106378498428) started by @VBSylvain*