### PR TITLE
🛡️ Sentinel: [Security Improvement] Prevent reverse tabnabbing on external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
This PR implements a standard security enhancement to prevent "Reverse Tabnabbing" vulnerabilities. 

By adding the `rel="noopener noreferrer"` attribute to anchor tags that use `target="_blank"`, we prevent newly opened tabs from gaining access to the `window.opener` API, which malicious or compromised external sites could otherwise use to navigate the original tab to a phishing page. It also stops referrer information from being passed along. This is an extremely safe security enhancement that has zero impact on application layout or styles.

---
*PR created automatically by Jules for task [1479341762967591099](https://jules.google.com/task/1479341762967591099) started by @VBSylvain*