### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
This PR fixes a MEDIUM severity reverse tabnabbing vulnerability.
By adding `rel="noopener noreferrer"` to external anchor tags that use `target="_blank"`, we prevent newly opened pages from maliciously manipulating the `window.opener` object to redirect the original page to a phishing site.

**Severity:** MEDIUM
**Vulnerability:** Reverse tabnabbing vulnerability due to `target="_blank"` without `rel="noopener noreferrer"`.
**Impact:** A maliciously compromised external site could redirect our application to a phishing site.
**Fix:** Added `rel="noopener noreferrer"` to all four instances in `js/app.js`.
**Verification:** Verified via `grep` and a temporary Python `verify.py` script.

---
*PR created automatically by Jules for task [4972283829498040931](https://jules.google.com/task/4972283829498040931) started by @VBSylvain*