### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-07 - [Reverse Tabnabbing Fix]
+**Vulnerability:** External links using target="_blank" without rel="noopener noreferrer" expose the site to reverse tabnabbing (window.opener hijacking).
+**Learning:** This specific vulnerability exists in dynamically generated HTML strings within js/app.js where external links to LinkedIn and Malt are rendered.
+**Prevention:** Always include rel="noopener noreferrer" when adding target="_blank" to external links, especially in dynamic template strings.

--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: External links dynamically rendered in `js/app.js` (for LinkedIn and Malt) used `target="_blank"` without the `rel="noopener noreferrer"` attribute. This exposed the site to reverse tabnabbing, allowing the opened window to potentially hijack the original window's location via `window.opener`.
🎯 Impact: An attacker who compromises the linked site could redirect the portfolio user to a phishing or malicious website.
🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` instances in `js/app.js`. Also logged this critical learning in `.jules/sentinel.md`.
✅ Verification: Created and ran a python script locally to verify that all `<a target="_blank">` tags in `js/app.js` contain `rel="noopener noreferrer"`. The verification passed.

---
*PR created automatically by Jules for task [14059912940643141833](https://jules.google.com/task/14059912940643141833) started by @VBSylvain*