### PR TITLE
🛡️ Sentinel: Add noopener noreferrer to external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🛡️ Sentinel: Add noopener noreferrer to external links

This PR adds a security enhancement by ensuring all external links (opening in a new tab via `target="_blank"`) explicitly use `rel="noopener noreferrer"`. 

While modern browsers frequently enforce `noopener` by default for `target="_blank"` links, explicitly declaring `rel="noopener noreferrer"` provides a solid defense-in-depth measure against reverse tabnabbing, where a newly opened page could exploit `window.opener` to redirect the original page to a malicious site. 

This enhancement adheres to standard frontend security guidelines.

---
*PR created automatically by Jules for task [11210557549390194094](https://jules.google.com/task/11210557549390194094) started by @VBSylvain*