### PR TITLE
🛡️ Sentinel: [Medium] Fix reverse tabnabbing vulnerability in social links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
**Security Improvement: Fix Reverse Tabnabbing**

This PR adds the `rel="noopener noreferrer"` attribute to all four occurrences of anchor tags (`<a>`) using `target="_blank"` in `js/app.js` (LinkedIn and Malt links in the hero and contact sections).

This is a standard security best practice that prevents a potential "reverse tabnabbing" vulnerability where the newly opened tab can manipulate the original tab's `window.opener`. While modern browsers largely default to `noopener` for `_blank` targets, explicitly adding these attributes ensures robust, backward-compatible protection and explicitly defines the security boundary without relying on browser default behaviors.

This was verified programmatically with an ad-hoc regex check ensuring all `target="_blank"` usages in the JS file are paired with `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [8344246180460342262](https://jules.google.com/task/8344246180460342262) started by @VBSylvain*