### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Reverse tabnabbing via `target="_blank"` links without `rel="noopener noreferrer"`.
🎯 **Impact**: A maliciously crafted linked page could gain control of the originating tab's `window.opener` object, potentially redirecting the user to a phishing site or stealing information.
🔧 **Fix**: Added `rel="noopener noreferrer"` to all external links in `js/app.js` (LinkedIn and Malt buttons in the Hero and Contact sections).
✅ **Verification**: Verified using a Playwright Python script that all rendered links with `target="_blank"` now include the correct `rel` attributes.

---
*PR created automatically by Jules for task [17445643524868950381](https://jules.google.com/task/17445643524868950381) started by @VBSylvain*