### PR TITLE
🛡️ Sentinel: Add rel="noopener noreferrer" to external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links opening in a new tab (`target="_blank"`) without `rel="noopener noreferrer"` can allow the newly opened page to access the `window.opener` object, potentially leading to a reverse tabnabbing attack where the original page is maliciously manipulated.
🎯 Impact: An attacker could redirect the original portfolio page to a phishing site or malicious destination.
🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` anchor tags in `js/app.js` (specifically in the `renderHero` and `renderContact` functions).
✅ Verification: Created and ran a custom Python script using Regex to ensure no `target="_blank"` tags exist without `rel="noopener noreferrer"` in `js/app.js`.

Note: `.jules/sentinel.md` journal is not updated as this is a standard security best practice and does not meet the "CRITICAL LEARNINGS ONLY" threshold.

---
*PR created automatically by Jules for task [8455320016312709928](https://jules.google.com/task/8455320016312709928) started by @VBSylvain*