### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-05-13 - Fixed Reverse Tabnabbing in External Links
+**Vulnerability:** External links generated dynamically in `js/app.js` using `target="_blank"` lacked the `rel="noopener noreferrer"` attribute. This allows the opened page to access the `window.opener` object, potentially leading to phishing attacks (reverse tabnabbing).
+**Learning:** Even dynamically generated links injecting `innerHTML` from trusted sources like `career.json` need standard HTML security attributes explicitly added to their template literals.
+**Prevention:** Always pair `target="_blank"` with `rel="noopener noreferrer"` when dynamically constructing anchor tags.

--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links with `target="_blank"` lacking `rel="noopener noreferrer"` (Reverse Tabnabbing).
🎯 Impact: The linked page gains access to the window object of the original page, which could be used for phishing attacks by replacing the original page with a malicious one.
🔧 Fix: Added `rel="noopener noreferrer"` to all external links in `js/app.js`.
✅ Verification: Ran a Python script to assert that all `target="_blank"` attributes are accompanied by the proper `rel` attribute.

---
*PR created automatically by Jules for task [7383967482885968980](https://jules.google.com/task/7383967482885968980) started by @VBSylvain*