### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
This PR adds `rel="noopener noreferrer"` to external anchor tags that use `target="_blank"` in `js/app.js` to mitigate reverse tabnabbing vulnerabilities.

Reverse tabnabbing occurs when a newly opened page is able to access the `window.opener` object of the original page, potentially allowing malicious pages to redirect the original tab to a phishing site. While modern browsers have begun applying `noopener` by default, explicitly declaring it remains a crucial security best practice to ensure defense-in-depth and backwards compatibility.

---
*PR created automatically by Jules for task [18216411458936975123](https://jules.google.com/task/18216411458936975123) started by @VBSylvain*