### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Reverse Tabnabbing (Missing `rel="noopener noreferrer"` on `target="_blank"` links).
🎯 **Impact:** If the external site (LinkedIn, Malt, etc.) is compromised or redirects to a malicious page, it could gain access to the originating page's `window.opener` object and maliciously navigate the user's original tab to a phishing site.
🔧 **Fix:** Added `rel="noopener noreferrer"` to the affected `<a>` tags in `js/app.js` (renderHero and renderContact functions).
✅ **Verification:** A Python script utilizing regex confirmed all `target="_blank"` links now correctly include the secure `rel` attribute.

---
*PR created automatically by Jules for task [2690588929782501384](https://jules.google.com/task/2690588929782501384) started by @VBSylvain*