### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,9 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Fix reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +258,9 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Fix reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links (`target="_blank"`) without `rel="noopener noreferrer"` can allow the newly opened page to gain partial control over the originating page via the `window.opener` object, potentially facilitating malicious redirects (phishing/reverse tabnabbing).
🎯 Impact: An attacker could change the `window.opener.location` to a malicious site, deceiving the user when they navigate back to the original tab.
🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` links in the dynamically rendered sections within `js/app.js` (`renderHero` and `renderContact`), mitigating the issue. Added Sentinel comments as required.
✅ Verification: Tested via Playwright script to verify dynamically injected links correctly include `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [13648064121744711575](https://jules.google.com/task/13648064121744711575) started by @VBSylvain*