### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing rel="noopener noreferrer" on target="_blank" links
+**Vulnerability:** External links in `js/app.js` use `target="_blank"` without `rel="noopener noreferrer"`.
+**Learning:** When links open in a new tab without these attributes, the newly opened page can gain partial access to the original window object via `window.opener`, creating a reverse tabnabbing vulnerability where the new page could redirect the original page to a malicious site.
+**Prevention:** Always add `rel="noopener noreferrer"` when using `target="_blank"` in anchor tags.

--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links using `target="_blank"` without `rel="noopener noreferrer"`.
🎯 Impact: This could allow newly opened pages to gain partial access to the original window object via `window.opener`, creating a reverse tabnabbing vulnerability where the new page could redirect the original page to a malicious site.
🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` anchor tags in `js/app.js`.
✅ Verification: Verified using a Python script checking the source code that all 4 occurrences of `target="_blank"` also contain `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [9716660798566628536](https://jules.google.com/task/9716660798566628536) started by @VBSylvain*