### PR TITLE
🛡️ Sentinel: [Medium] Fix reverse tabnabbing on external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-20 - [Reverse Tabnabbing Vulnerability in Target Blank Links]
+**Vulnerability:** External links generated dynamically using `target="_blank"` without proper `rel` attributes can expose the application to reverse tabnabbing via `window.opener`.
+**Learning:** Found dynamically rendered anchor elements in `js/app.js` using `target="_blank"` where `rel="noopener noreferrer"` was omitted, likely because they were dynamically generated template literals.
+**Prevention:** Always verify that dynamically injected external links explicitly enforce `rel="noopener noreferrer"`.

--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 **Severity**: Medium
💡 **Vulnerability**: Reverse tabnabbing vulnerability where dynamically generated external links with `target="_blank"` omitted `rel="noopener noreferrer"`. This could allow a malicious target site to hijack the original tab's URL using `window.opener`.
🎯 **Impact**: A user clicking an external link (like LinkedIn or Malt) could have their original portfolio tab redirected to a phishing site.
🔧 **Fix**: Added `rel="noopener noreferrer"` to the `a` tags generated in `js/app.js`.
✅ **Verification**: A Playwright script was used to functionally verify that all `a` tags with `target="_blank"` now have the correct `rel` attribute in the DOM.

---
*PR created automatically by Jules for task [2799995867129293616](https://jules.google.com/task/2799995867129293616) started by @VBSylvain*