### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing by adding rel="noopener noreferrer"

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Reverse Tabnabbing (Missing `rel="noopener noreferrer"` on `target="_blank"` links).
🎯 Impact: A newly opened page could potentially access the `window.opener` object and redirect the original page to a malicious URL, facilitating phishing attacks.
🔧 Fix: Added `rel="noopener noreferrer"` to all external LinkedIn and Malt links within `js/app.js` (`renderHero` and `renderContact` functions).
✅ Verification: Created and ran a Playwright script that verified all `a[target="_blank"]` tags present in the rendered DOM correctly include the `rel="noopener noreferrer"` attributes.

---
*PR created automatically by Jules for task [14271686465537605989](https://jules.google.com/task/14271686465537605989) started by @VBSylvain*