### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability in external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -190,8 +190,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -257,8 +257,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Reverse Tabnabbing via `target="_blank"` without `rel="noopener noreferrer"`.
**Impact:** Malicious external sites could potentially use `window.opener.location` to redirect the original portfolio page to a phishing site, deceiving users.
**Fix:** Added the `rel="noopener noreferrer"` attribute to the external links (LinkedIn and Malt) generated in `renderHero` and `renderContact` within `js/app.js`.
**Verification:** Verified via a Python regex script (`verify_links.py`) that confirmed all `target="_blank"` occurrences in `js/app.js` now include the correct `rel` attribute. Tested changes safely locally.

---
*PR created automatically by Jules for task [17884617416386741922](https://jules.google.com/task/17884617416386741922) started by @VBSylvain*