### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-25 - Prevent Reverse Tabnabbing
+**Vulnerability:** External links with target="_blank" without rel="noopener noreferrer".
+**Learning:** Found in dynamically generated HTML via JS strings (js/app.js).
+**Prevention:** Always add rel="noopener noreferrer" to external links utilizing target="_blank" to prevent reverse tabnabbing via window.opener.

--- a/js/app.js
+++ b/js/app.js
@@ -270,8 +270,9 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- Security: added rel="noopener noreferrer" to prevent reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -337,8 +338,9 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- Security: added rel="noopener noreferrer" to prevent reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Severity:** MEDIUM
**Vulnerability:** Reverse Tabnabbing
**Impact:** External links utilizing `target="_blank"` without the `rel="noopener noreferrer"` attributes can potentially allow the newly opened page to hijack the original page by maliciously modifying `window.opener.location`, leading to phishing or redirection attacks.
**Fix:** Added the `rel="noopener noreferrer"` attributes to the external links in `js/app.js` (LinkedIn and Malt buttons).
**Verification:** Verified via an ad-hoc Python script checking the presence of the required attributes alongside `target="_blank"`.

---
*PR created automatically by Jules for task [13622172706220223053](https://jules.google.com/task/13622172706220223053) started by @VBSylvain*