### PR TITLE
feat(theme): add DBZ scouter experience

### DIFF
--- a/assets/reticle.svg
+++ b/assets/reticle.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="#5cff7a" stroke-width="1.5">
+  <circle cx="50" cy="50" r="38" opacity="0.4"></circle>
+  <circle cx="50" cy="50" r="22" opacity="0.6"></circle>
+  <circle cx="50" cy="50" r="3" fill="#5cff7a" stroke="none"></circle>
+  <line x1="50" y1="4" x2="50" y2="20"></line>
+  <line x1="50" y1="80" x2="50" y2="96"></line>
+  <line x1="4" y1="50" x2="20" y2="50"></line>
+  <line x1="80" y1="50" x2="96" y2="50"></line>
+  <path d="M14 14 L26 14 L26 16 L16 16 L16 26 L14 26 Z" fill="#5cff7a" stroke="none"></path>
+  <path d="M86 14 L74 14 L74 16 L84 16 L84 26 L86 26 Z" fill="#5cff7a" stroke="none"></path>
+  <path d="M14 86 L26 86 L26 84 L16 84 L16 74 L14 74 Z" fill="#5cff7a" stroke="none"></path>
+  <path d="M86 86 L74 86 L74 84 L84 84 L84 74 L86 74 Z" fill="#5cff7a" stroke="none"></path>
+</svg>

--- a/assets/sv-saiyan-crest.svg
+++ b/assets/sv-saiyan-crest.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="navy" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a2772"></stop>
+      <stop offset="100%" stop-color="#0d143a"></stop>
+    </linearGradient>
+  </defs>
+  
+  <polygon points="60,8 112,60 60,112 8,60" fill="url(#navy)" stroke="#e8b339" stroke-width="3"></polygon>
+  <polygon points="60,22 98,60 60,98 22,60" fill="none" stroke="#e8b339" stroke-width="1.5" opacity="0.7"></polygon>
+  <text x="60" y="74" text-anchor="middle" font-family="Impact, Arial Black, sans-serif" font-size="38" font-weight="900" fill="#e8b339" letter-spacing="-2">SV</text>
+  <circle cx="60" cy="60" r="55" fill="none" stroke="#5cff7a" stroke-width="0.6" opacity="0.4" stroke-dasharray="2 3"></circle>
+</svg>

--- a/css/style.css
+++ b/css/style.css
@@ -470,3 +470,77 @@ section { padding: 8rem 0; }
     .contact-card h2 { font-size: 2.5rem; }
     .landing-content h1 { font-size: 3rem; }
 }
+
+/* ============================================================
+   SCOUTER THEME BUTTON - Mini scouter lens
+   ============================================================ */
+.theme-btn[data-theme="scouter"] {
+    background:
+        radial-gradient(ellipse at 30% 30%, rgba(255, 255, 255, 0.18) 0%, transparent 35%),
+        radial-gradient(ellipse at center, rgba(92, 214, 255, 0.12) 0%, rgba(6, 9, 20, 0.85) 75%);
+    border: 1px solid rgba(76, 211, 255, 0.55);
+    box-shadow: inset 0 0 22px rgba(92, 214, 255, 0.25),
+                0 0 18px rgba(92, 214, 255, 0.15);
+    overflow: hidden;
+}
+
+.theme-btn[data-theme="scouter"]::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: repeating-linear-gradient(
+        to bottom,
+        transparent 0 2px,
+        rgba(0, 0, 0, 0.4) 3px,
+        transparent 4px
+    );
+    mix-blend-mode: multiply;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.theme-btn[data-theme="scouter"]::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -4px;
+    height: 4px;
+    background: linear-gradient(to bottom, transparent, #5cd6ff, transparent);
+    box-shadow: 0 0 14px rgba(92, 214, 255, 0.7);
+    animation: scoutScanBeam 3s linear infinite;
+    z-index: 1;
+}
+
+@keyframes scoutScanBeam {
+    0% { transform: translateY(0); opacity: 0; }
+    10% { opacity: 1; }
+    100% { transform: translateY(180px); opacity: 0; }
+}
+
+.theme-btn[data-theme="scouter"] .dbz-label {
+    font-family: 'Orbitron', 'Inter', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-shadow: 0 0 14px rgba(92, 214, 255, 0.7);
+    position: relative;
+    z-index: 2;
+}
+
+.theme-btn[data-theme="scouter"]:hover {
+    border-color: #c77dff;
+    box-shadow: inset 0 0 26px rgba(199, 125, 255, 0.3),
+                0 0 24px rgba(199, 125, 255, 0.45);
+}
+
+.theme-btn[data-theme="scouter"] .badge {
+    background: #ff2238;
+    color: #ffffff;
+    font-family: 'Share Tech Mono', 'Courier New', monospace;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    padding: 2px 6px;
+    box-shadow: 0 0 10px rgba(255, 34, 56, 0.6);
+    position: relative;
+    z-index: 2;
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Sylvain VIZZINI — Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Inter:wght@300;400;500;600;700&family=Italiana&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Inter:wght@300;400;500;600;700&family=Italiana&family=Libre+Baskerville:wght@400;700&family=Orbitron:wght@500;700&family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/90s.css">
     <link rel="stylesheet" href="css/pizzeria.css">
@@ -18,14 +18,15 @@
     <div id="cursor-dot" class="cursor-dot"></div>
 
     <!-- Theme Selector Landing Screen -->
-    <div id="landing-screen" class="landing-screen">
+    <div id="landing-screen" class="landing-screen" data-anchor="themes">
         <div class="landing-content">
             <h1>Sylvain VIZZINI</h1>
             <p class="landing-subtitle">Scrum Master · Product Manager · Consultant Agile Senior</p>
             <div class="theme-picker">
                 <button class="theme-btn active" data-theme="standard">Standard</button>
-                <button class="theme-btn disabled" data-theme="dbz">
-                    Dragon Ball Z <span class="badge">Coming Soon</span>
+                <button class="theme-btn" data-theme="scouter" data-route="scouter/index.html">
+                    <span class="dbz-label">Dragon Ball Z</span>
+                    <span class="badge">SCAN</span>
                 </button>
                 <button class="theme-btn disabled" data-theme="naruto">
                     Naruto <span class="badge">Coming Soon</span>

--- a/js/app.js
+++ b/js/app.js
@@ -51,7 +51,8 @@ async function init() {
     setupGodTierEffects();
     applyState();
 
-    if (localStorage.getItem('portfolio-theme')) {
+    const shouldShowThemePicker = window.location.hash === '#landing-screen' || window.location.hash === '#themes';
+    if (!shouldShowThemePicker && localStorage.getItem('portfolio-theme')) {
         showPortfolio();
     }
 
@@ -140,6 +141,10 @@ function setupEventListeners() {
     document.querySelectorAll('.theme-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             if (btn.classList.contains('disabled')) return;
+            if (btn.dataset.route) {
+                window.location.href = btn.dataset.route;
+                return;
+            }
             state.currentTheme = btn.dataset.theme;
             localStorage.setItem('portfolio-theme', state.currentTheme);
             showPortfolio();

--- a/scouter/CombatStat.jsx
+++ b/scouter/CombatStat.jsx
@@ -1,0 +1,26 @@
+/* global React */
+const { useEffect: useEffectCS, useRef: useRefCS } = React;
+
+function CombatStat({ skill, lang, idx, battleMode, toPowerLevel }) {
+  const fillRef = useRefCS(null);
+  useEffectCS(() => {
+    const t = setTimeout(() => {
+      if (fillRef.current) fillRef.current.style.width = `${skill.score}%`;
+    }, 200 + idx * 60);
+    return () => clearTimeout(t);
+  }, [skill.score, idx]);
+
+  const isHot = skill.score >= 85;
+  const display = battleMode ? toPowerLevel(skill[`skill_${lang}`] + skill.score) : skill.score * 100;
+  return (
+    <div className="combat-stat" onMouseEnter={() => window.SCOUTER_SFX?.play('hover')}>
+      <div className="name">[ {String(idx + 1).padStart(2, '0')} ] {skill[`skill_${lang}`]}</div>
+      <div className="bar">
+        <div ref={fillRef} className={"fill " + (isHot ? 'hot' : '')} style={{ width: '0%' }} />
+      </div>
+      <div className={"pct " + (isHot ? 'hot' : '')}>{display}</div>
+    </div>
+  );
+}
+
+window.CombatStat = CombatStat;

--- a/scouter/FieldReport.jsx
+++ b/scouter/FieldReport.jsx
@@ -1,0 +1,34 @@
+/* global React */
+function FieldReport({ exp, lang, idx }) {
+  const start = exp.start_date ? new Date(exp.start_date) : null;
+  const end = exp.current ? null : (exp.end_date ? new Date(exp.end_date) : null);
+  const fmt = (d) => d ? d.toLocaleDateString(lang === 'fr' ? 'fr-FR' : 'en-US', { month: 'short', year: 'numeric' }).toUpperCase() : '—';
+  const present = lang === 'fr' ? 'PRÉSENT' : 'PRESENT';
+
+  return (
+    <article className={"report " + (exp.current ? 'current' : '')} onMouseEnter={() => window.SCOUTER_SFX?.play('hover')}>
+      <div className="head">
+        <div>
+          <div className="id">
+            [ FIELD REPORT · {String(idx + 1).padStart(3, '0')} ·{' '}
+            {exp.current ? <span className="blinker">ACTIVE</span> : 'ARCHIVED'} ]
+          </div>
+          <h3 className="role">{exp[`role_${lang}`]}</h3>
+          <div className="company">{exp.company || '— PERSONAL OPS —'}</div>
+          <div className="meta">
+            {fmt(start)} — {exp.current ? present : fmt(end)}
+            {' · '}
+            {exp[`location_${lang}`]}
+          </div>
+        </div>
+        <img className="reticle" src="../assets/reticle.svg" alt="" />
+      </div>
+      <p className="desc">{exp[`description_${lang}`]}</p>
+      <div className="tags">
+        {exp.tags.slice(0, 8).map((t) => <span className="tag" key={t}>#{t}</span>)}
+      </div>
+    </article>
+  );
+}
+
+window.FieldReport = FieldReport;

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -1,0 +1,62 @@
+/* global React */
+function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toPowerLevel }) {
+  const isHot = (val) => /^[+\-−]?\d+/.test(val) && parseInt(val.replace(/\D/g, ''), 10) >= 40;
+  const sfx = () => window.SCOUTER_SFX?.play('hover');
+
+  return (
+    <div className="hero-grid">
+      <div className="hero-text">
+        <div className="preamble">
+          <span className="dot blinker" />
+          <span>SCAN INITIATED · TARGET ACQUIRED</span>
+          <span style={{ color: 'var(--fg-deemph)' }}>·</span>
+          <span>{lang === 'fr' ? 'ANALYSE EN COURS' : 'ANALYZING'}</span>
+        </div>
+
+        <h1 className="name">
+          {identity.first_name}<span className="sep"> · </span>{identity.last_name}
+        </h1>
+
+        <div className="role">{identity[`role_${lang}`]}</div>
+
+        <p className="tagline">{identity[`tagline_${lang}`]}</p>
+
+        <div className="btn-row">
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+            UPLINK · LINKEDIN
+          </a>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+            UPLINK · MALT
+          </a>
+        </div>
+
+        <button
+          className={"battle-toggle " + (battleMode ? 'on' : '')}
+          onClick={onToggleBattle}
+          onMouseEnter={sfx}
+          title={lang === 'fr' ? 'Easter egg : convertir en niveaux de puissance' : 'Easter egg: convert to power levels'}
+        >
+          {battleMode
+            ? (lang === 'fr' ? '◉ MODE COMBAT ACTIVÉ — CLIQUEZ POUR REVENIR' : '◉ BATTLE MODE ACTIVE — CLICK TO REVERT')
+            : (lang === 'fr' ? '◎ ENGAGER LE MODE COMBAT — LIRE LES NIVEAUX DE PUISSANCE' : '◎ ENGAGE BATTLE MODE — READ POWER LEVELS')}
+        </button>
+      </div>
+
+      <div className="hero-stats-grid">
+        {heroStats.map((s, i) => {
+          const value = battleMode ? toPowerLevel(s.value) : s.value;
+          const hot = battleMode || isHot(s.value);
+          return (
+            <div className="stat-cell" key={i} onMouseEnter={sfx}>
+              <div className="stat-id">[ STAT.{String(i + 1).padStart(2, '0')} {battleMode ? '· POWER' : ''} ]</div>
+              <div className={"stat-val " + (hot ? 'hot' : '')}>{value}</div>
+              <div className="stat-lbl">{battleMode ? (lang === 'fr' ? 'NIVEAU DE PUISSANCE' : 'POWER LEVEL') : s[`label_${lang}`]}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+window.HeroLockOn = HeroLockOn;

--- a/scouter/LensOverlay.jsx
+++ b/scouter/LensOverlay.jsx
@@ -1,0 +1,63 @@
+/* global React */
+function LensOverlay() {
+  return (
+    <div className="lens">
+      <svg viewBox="0 0 1920 1080" preserveAspectRatio="none" aria-hidden="true">
+        <defs>
+          <radialGradient id="lens-tint-grad" cx="50%" cy="50%" r="65%">
+            <stop offset="0%" stopColor="#5cd6ff" stopOpacity="0" />
+            <stop offset="55%" stopColor="#5cd6ff" stopOpacity="0.04" />
+            <stop offset="90%" stopColor="#020410" stopOpacity="0.65" />
+            <stop offset="100%" stopColor="#000000" stopOpacity="0.95" />
+          </radialGradient>
+          <linearGradient id="rim-grad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%"  stopColor="#9fdbff" stopOpacity="0.5" />
+            <stop offset="50%" stopColor="#5cd6ff" stopOpacity="1" />
+            <stop offset="100%" stopColor="#1f8ed0" stopOpacity="0.6" />
+          </linearGradient>
+        </defs>
+
+        {/* the tinted "glass" — full viewport */}
+        <rect x="0" y="0" width="1920" height="1080" fill="url(#lens-tint-grad)" />
+
+        {/* the curved lens rim — a fat asymmetric oval inset by ~30px,
+            this is the *inside* edge of the scouter lens */}
+        <path
+          d="M 30 90
+             Q 960 0 1890 90
+             L 1890 990
+             Q 960 1080 30 990
+             Z"
+          fill="none" stroke="url(#rim-grad)" strokeWidth="3"
+          style={{ filter: 'drop-shadow(0 0 10px rgba(76, 211, 255, 0.6))' }}
+        />
+
+        {/* outer hairline */}
+        <path
+          d="M 18 70
+             Q 960 -16 1902 70
+             L 1902 1010
+             Q 960 1096 18 1010
+             Z"
+          fill="none" stroke="#4cd3ff" strokeWidth="1" opacity="0.4"
+        />
+
+        {/* lens reflection — diagonal sheen */}
+        <path
+          d="M 100 120 L 540 60 L 720 90 L 280 150 Z"
+          fill="#9fdbff" opacity="0.06"
+        />
+
+        {/* small registration marks along the rim */}
+        {[200, 480, 760, 1160, 1440, 1720].map((x) => (
+          <g key={x}>
+            <line x1={x} y1="40" x2={x} y2="56" stroke="#5cd6ff" strokeWidth="1" opacity="0.6" />
+            <line x1={x} y1="1024" x2={x} y2="1040" stroke="#5cd6ff" strokeWidth="1" opacity="0.6" />
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+window.LensOverlay = LensOverlay;

--- a/scouter/PowerLevelCard.jsx
+++ b/scouter/PowerLevelCard.jsx
@@ -1,0 +1,21 @@
+/* global React */
+function PowerLevelCard({ metric, lang, idx, battleMode, toPowerLevel }) {
+  const value = battleMode ? toPowerLevel(metric.value) : metric.value;
+  const numeric = parseInt(metric.value.replace(/[^\d]/g, ''), 10) || 0;
+  const isHot = metric.is_overflow || numeric >= 40;
+  const cls = battleMode ? 'battle' : (isHot ? 'hot' : '');
+  return (
+    <article className="power-card" onMouseEnter={() => window.SCOUTER_SFX?.play('hover')}>
+      <div className="pc-head">
+        <div className="pc-id">[ POWER · {String(idx + 1).padStart(3, '0')} ]</div>
+        <img className="reticle" src="../assets/reticle.svg" alt="" />
+      </div>
+      <div className={"pc-val " + cls}>{value}</div>
+      <div className="pc-lbl">{battleMode ? (lang === 'fr' ? 'NIVEAU DE PUISSANCE DÉTECTÉ' : 'POWER LEVEL DETECTED') : metric[`label_${lang}`]}</div>
+      <p className="pc-desc">{metric[`description_${lang}`]}</p>
+      <div className="pc-src">{metric[`source_${lang}`]}</div>
+    </article>
+  );
+}
+
+window.PowerLevelCard = PowerLevelCard;

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -1,0 +1,34 @@
+/* global React */
+function RankInsignia({ cert, lang }) {
+  return (
+    <div className="rank" onMouseEnter={() => window.SCOUTER_SFX?.play('hover')}>
+      <div className="badge"><span>{cert.abbreviation || cert[`name_${lang}`].split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase()}</span></div>
+      <div className="info">
+        <div className="year">{cert.year}</div>
+        <div className="name">{cert[`name_${lang}`]}</div>
+        <div className="org">◆ {cert.organization}</div>
+      </div>
+    </div>
+  );
+}
+
+function ContactBeacon({ contact, lang }) {
+  const sfx = () => window.SCOUTER_SFX?.play('hover');
+  return (
+    <section className="beacon">
+      <div className="beacon-id">
+        <span className="dot crimson blinker" style={{ display: 'inline-block', marginRight: 8, verticalAlign: 'middle' }} />
+        [ INCOMING TRANSMISSION REQUEST ]
+      </div>
+      <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
+      <p>{contact[`message_${lang}`]}</p>
+      <div className="btn-row">
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+      </div>
+    </section>
+  );
+}
+
+window.RankInsignia = RankInsignia;
+window.ContactBeacon = ContactBeacon;

--- a/scouter/Scouter.jsx
+++ b/scouter/Scouter.jsx
@@ -1,0 +1,117 @@
+/* global React */
+const { useState: useScS, useEffect: useScE } = React;
+
+// 4 gauges along the bottom arc; dip follows the lens bottom curve
+const ARC_GAUGES = (battleMode, tele) => [
+  { id: 'ki',    label: 'KI · LV',  v: tele.a, cls: '' },
+  { id: 'bio',   label: 'BIO·SIG',  v: tele.b, cls: 'violet' },
+  { id: 'lock',  label: 'LOCK',     v: tele.c, cls: '' },
+  { id: 'mode',  label: battleMode ? 'BATTLE' : 'SCAN', v: battleMode ? '◉' : '◎', cls: battleMode ? 'alert' : '' }
+];
+
+function ScouterChrome({ lang, sectionIdx, sectionCount, sectionTitles, onJump, soundOn, onSoundToggle, battleMode, onToggleLang, onOpenThemes }) {
+  const [time, setTime] = useScS(() => new Date());
+  useScE(() => {
+    const id = setInterval(() => setTime(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const hh = String(time.getHours()).padStart(2, '0');
+  const mm = String(time.getMinutes()).padStart(2, '0');
+  const ss = String(time.getSeconds()).padStart(2, '0');
+
+  const [tele, setTele] = useScS({ a: 1240, b: 9.4, c: 0.82 });
+  useScE(() => {
+    const id = setInterval(() => {
+      setTele({
+        a: 1000 + Math.floor(Math.random() * 800),
+        b: (8 + Math.random() * 2).toFixed(1),
+        c: (0.7 + Math.random() * 0.3).toFixed(2)
+      });
+    }, 1400);
+    return () => clearInterval(id);
+  }, []);
+
+  // Each gauge dip follows sin(π*x) so it hugs the bottom-lens curve.
+  // 4 gauges → x ∈ {0, 0.33, 0.67, 1}.  Max dip ~28px.
+  const gauges = ARC_GAUGES(battleMode, tele);
+
+  return (
+    <div className="chrome">
+      <div className="chrome-bar top">
+        <span className="dot blinker" />
+        <span>SCOUTER MK·IV</span>
+        <span className="sep">·</span>
+        <span>TGT: <strong style={{ color: 'var(--hud-amber)' }}>SYLVAIN.V</strong></span>
+        <span className="sep">·</span>
+        <span>SECTOR: BILIEU·ISÈRE</span>
+
+        <span className="grow" />
+
+        <div className="section-indicator" title="Jump to section">
+          {sectionTitles.map((t, i) => (
+            <div
+              key={i}
+              className={"si " + (i === sectionIdx ? 'active' : '')}
+              onClick={() => onJump(i)}
+              title={t}
+            />
+          ))}
+        </div>
+
+        <span className="sep">·</span>
+        <a className="bar-btn" href="../index.html#landing-screen" title="Back to themes">
+          ◀ BACK
+        </a>
+        <button className="bar-btn violet" onClick={onOpenThemes} title="Switch theme">
+          ◆ THEMES
+        </button>
+        <button className="bar-btn" onClick={onToggleLang} title="Switch language (L)">
+          {lang === 'fr' ? 'FR ▸ EN' : 'EN ▸ FR'}
+        </button>
+        <button className="bar-btn" onClick={onSoundToggle} title="Toggle sound">
+          <span className={"dot " + (soundOn ? '' : 'crimson')} />
+          {soundOn ? 'SFX' : 'MUTE'}
+        </button>
+        <span className="sep">·</span>
+        <span style={{ color: 'var(--hud-amber)' }}>{hh}:{mm}:{ss}</span>
+      </div>
+
+      {/* Arc of gauges along the bottom lens curve */}
+      <div className="gauge-arc">
+        {gauges.map((g, i) => {
+          const x = i / (gauges.length - 1);
+          const dip = Math.sin(Math.PI * x) * 28;
+          return (
+            <div key={g.id} className="gauge-wrap" style={{ '--dip': `${dip}px` }}>
+              <div className={"gauge " + g.cls}>
+                <div>{g.label}</div>
+                <div className="v">{g.v}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="chrome-bar bot">
+        <span className="dot amber blinker-slow" />
+        <span>UPLINK STABLE</span>
+        <span className="sep">·</span>
+        <span>15Y RECORD</span>
+        <span className="sep">·</span>
+        <span>PSM I · PSPO I · 6σ YB</span>
+
+        <span className="grow" />
+
+        <span style={{ color: battleMode ? 'var(--hud-crimson)' : 'var(--hud-violet)' }}>
+          {battleMode ? '◉ BATTLE MODE · POWER LVL > 9000' : '◎ STANDARD READOUT MODE'}
+        </span>
+        <span className="sep">·</span>
+        <span>{lang.toUpperCase()}</span>
+        <span className="sep">·</span>
+        <span>EOF</span>
+      </div>
+    </div>
+  );
+}
+
+window.ScouterChrome = ScouterChrome;

--- a/scouter/ThemesOverlay.jsx
+++ b/scouter/ThemesOverlay.jsx
@@ -1,0 +1,43 @@
+/* global React */
+const THEMES = [
+  { id: 'standard', name: 'STANDARD', sub: 'Glass / Mesh', badge: 'BASE', disabled: false, route: '../index.html' },
+  { id: 'scouter', name: 'SCOUTER', sub: 'DBZ / Battle HUD', badge: 'ACTIVE', disabled: false, active: true },
+  { id: 'pizzeria', name: 'PIZZERIA', sub: 'Folded menu dossier', badge: 'NEW', disabled: false, route: '../index.html' },
+  { id: '90s', name: "90's WEB", sub: 'Geocities revival', badge: 'NEW', disabled: false, route: '../index.html' },
+  { id: 'naruto', name: 'NARUTO', sub: 'Coming Soon', badge: 'SOON', disabled: true },
+  { id: 'wwe', name: 'WWE', sub: 'Coming Soon', badge: 'SOON', disabled: true }
+];
+
+function ThemesOverlay({ lang, onClose, onPick }) {
+  return (
+    <div className="themes-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="themes-panel">
+        <button className="themes-close" onClick={onClose} aria-label="Close">x</button>
+        <h3>{lang === 'fr' ? 'Choisir un theme' : 'Choose a theme'}</h3>
+        <div className="sub">[ 6 PROFILES DETECTED / 4 ACTIVE / 2 INCOMING ]</div>
+        <div className="themes-grid">
+          {THEMES.map((t) => (
+            <button
+              key={t.id}
+              className={'theme-card ' + (t.active ? 'active ' : '') + (t.disabled ? 'disabled' : '')}
+              disabled={t.disabled}
+              onClick={() => onPick(t)}
+              onMouseEnter={() => window.SCOUTER_SFX?.play('hover')}
+            >
+              <span>{t.name}</span>
+              <span style={{ fontSize: 9, opacity: 0.7, letterSpacing: '0.18em' }}>{t.sub}</span>
+              <span className="badge">{t.badge}</span>
+            </button>
+          ))}
+        </div>
+        <div style={{ marginTop: 'var(--sp-5)', fontFamily: 'var(--font-readout)', fontSize: 10, letterSpacing: '0.22em', color: 'var(--fg-muted)', textTransform: 'uppercase' }}>
+          {lang === 'fr'
+            ? 'Les profils actifs ouvrent leur experience correspondante. SCOUTER est le theme actif ici.'
+            : 'Active profiles open their matching experience. SCOUTER is the active theme here.'}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.ThemesOverlay = ThemesOverlay;

--- a/scouter/app.jsx
+++ b/scouter/app.jsx
@@ -1,0 +1,311 @@
+/* global React, ReactDOM, ScouterChrome, HeroLockOn, PowerLevelCard, CombatStat, FieldReport, RankInsignia, ContactBeacon, LensOverlay */
+const { useState: useS, useEffect: useE, useMemo: useM, useCallback: useCB, useRef: useR } = React;
+
+const STR = {
+  fr: {
+    section_hero: '00 / CIBLE',
+    section_results: '01 / PUISSANCE',
+    section_skills: '02 / STATS DE COMBAT',
+    section_timeline: '03 / RAPPORTS DE TERRAIN',
+    section_certs: '04 / INSIGNES DE RANG',
+    section_contact: '05 / CONTACT',
+    title_results: 'PUISSANCE · IMPACT',
+    title_skills: 'STATS DE COMBAT',
+    title_timeline: 'RAPPORTS DE TERRAIN',
+    title_certs: 'INSIGNES DE RANG',
+    title_contact: 'BALISE DE CONTACT',
+    boot: ['INITIALISATION SCOUTER MK-IV…', 'CALIBRAGE LENTILLE PHOSPHORE…', 'TRIANGULATION CIBLE…', 'CIBLE : SYLVAIN VIZZINI', 'NIVEAU DE PUISSANCE : > 9000', 'PRÊT.'],
+    next: 'SUIVANT', prev: 'PRÉCÉDENT',
+    detected: 'DÉTECTÉ',
+    records: 'ENREGISTREMENTS'
+  },
+  en: {
+    section_hero: '00 / TARGET',
+    section_results: '01 / POWER',
+    section_skills: '02 / COMBAT STATS',
+    section_timeline: '03 / FIELD REPORTS',
+    section_certs: '04 / RANK INSIGNIA',
+    section_contact: '05 / CONTACT',
+    title_results: 'POWER · IMPACT',
+    title_skills: 'COMBAT STATS',
+    title_timeline: 'FIELD REPORTS',
+    title_certs: 'RANK INSIGNIA',
+    title_contact: 'CONTACT BEACON',
+    boot: ['BOOTING SCOUTER MK-IV…', 'CALIBRATING PHOSPHOR LENS…', 'TRIANGULATING TARGET…', 'TARGET: SYLVAIN VIZZINI', 'POWER LEVEL: > 9000', 'READY.'],
+    next: 'NEXT', prev: 'PREV',
+    detected: 'DETECTED',
+    records: 'RECORDS'
+  }
+};
+
+// Deterministic fake power-level for any input. Rounded to nearest 100.
+function toPowerLevel(seed) {
+  const s = String(seed);
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = ((h * 31) + s.charCodeAt(i)) | 0;
+  const n = 4500 + (Math.abs(h) % 15500);
+  return (Math.round(n / 100) * 100).toLocaleString();
+}
+
+function BootScreen({ lang, onDone }) {
+  const [step, setStep] = useS(0);
+  const [out, setOut] = useS(false);
+  const lines = STR[lang].boot;
+  useE(() => {
+    window.SCOUTER_SFX?.play('boot');
+    if (step < lines.length) {
+      const t = setTimeout(() => { setStep(step + 1); window.SCOUTER_SFX?.play('beep'); }, 260);
+      return () => clearTimeout(t);
+    }
+    const t = setTimeout(() => { setOut(true); window.SCOUTER_SFX?.play('chirp'); setTimeout(onDone, 400); }, 500);
+    return () => clearTimeout(t);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, lines.length]);
+
+  return (
+    <div className={"bootscreen " + (out ? 'dismissed' : '')}>
+      <div className="lines">
+        <img className="crest" src="../assets/sv-saiyan-crest.svg" alt="" />
+        {lines.slice(0, step).map((l, i) => (
+          <div className="line" key={i}>
+            <span className="ok">[ OK ]</span>
+            <span>{l}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NavArrow({ direction, label, sublabel, onDone }) {
+  useE(() => {
+    const t = setTimeout(onDone, 720);
+    return () => clearTimeout(t);
+  }, [onDone]);
+  return (
+    <div className={"nav-arrow " + direction}>
+      <div className="chevron" />
+      <div className="lbl">
+        <span className="small">{sublabel}</span>
+        <span className="big">{label}</span>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [lang, setLang] = useS(() => localStorage.getItem('scouter-lang') || 'fr');
+  const [data, setData] = useS(null);
+  const [booted, setBooted] = useS(false);
+  const [sectionIdx, setSectionIdx] = useS(0);
+  const [arrow, setArrow] = useS(null);
+  const [battleMode, setBattleMode] = useS(false);
+  const [soundOn, setSoundOn] = useS(() => window.SCOUTER_SFX?.enabled() ?? true);
+  const [themesOpen, setThemesOpen] = useS(false);
+  const swipingRef = useR(false);
+
+  useE(() => { fetch('../career.json').then(r => r.json()).then(setData); }, []);
+  useE(() => { localStorage.setItem('scouter-lang', lang); }, [lang]);
+
+  const sortedExp = useM(() => data ? [...data.experiences]
+    .sort((a, b) => new Date(b.start_date || '1900') - new Date(a.start_date || '1900')) : [], [data]);
+  const sortedSkills = useM(() => data ? [...data.skills].sort((a, b) => b.score - a.score) : [], [data]);
+
+  const t = STR[lang];
+  const sectionTitles = [t.section_hero, t.section_results, t.section_skills, t.section_timeline, t.section_certs, t.section_contact];
+  const sectionCount = sectionTitles.length;
+
+  const goTo = useCB((i, dir) => {
+    if (i < 0 || i >= sectionCount) return;
+    if (i === sectionIdx) return;
+    const direction = dir || (i > sectionIdx ? 'right' : 'left');
+    const labelTitle = [
+      lang === 'fr' ? 'CIBLE' : 'TARGET',
+      t.title_results, t.title_skills, t.title_timeline, t.title_certs, t.title_contact
+    ][i];
+    window.SCOUTER_SFX?.play(direction === 'right' ? 'next' : 'prev');
+    setArrow({ direction, label: labelTitle, sublabel: `[ ${direction === 'right' ? t.next : t.prev} ] · ${t.detected}` });
+    setSectionIdx(i);
+  }, [sectionIdx, sectionCount, lang, t]);
+
+  const next = useCB(() => goTo(sectionIdx + 1, 'right'), [sectionIdx, goTo]);
+  const prev = useCB(() => goTo(sectionIdx - 1, 'left'), [sectionIdx, goTo]);
+
+  useE(() => {
+    const onKey = (e) => {
+      if (e.key === 'ArrowRight') next();
+      else if (e.key === 'ArrowLeft') prev();
+      else if (e.key === 'b' || e.key === 'B') toggleBattle();
+      else if (e.key === 'l' || e.key === 'L') setLang(l => l === 'fr' ? 'en' : 'fr');
+      else if (e.key === 't' || e.key === 'T') setThemesOpen(v => !v);
+      else if (e.key === 'Escape') setThemesOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [next, prev]);
+
+  const toggleBattle = useCB(() => {
+    setBattleMode(b => {
+      window.SCOUTER_SFX?.play(b ? 'powerdown' : 'powerup');
+      return !b;
+    });
+  }, []);
+
+  const toggleSound = useCB(() => {
+    const newVal = !soundOn;
+    window.SCOUTER_SFX?.set(newVal);
+    setSoundOn(newVal);
+    if (newVal) window.SCOUTER_SFX?.play('chirp');
+  }, [soundOn]);
+
+  if (!data) return null;
+
+  return (
+    <React.Fragment>
+      {!booted && <BootScreen lang={lang} onDone={() => setBooted(true)} />}
+
+      <LensOverlay />
+      <div className="lens-aberration" />
+      <div className="scanlines" />
+      <div className="scan-beam" />
+
+      <ScouterChrome
+        lang={lang}
+        sectionIdx={sectionIdx}
+        sectionCount={sectionCount}
+        sectionTitles={sectionTitles}
+        onJump={(i) => goTo(i)}
+        soundOn={soundOn}
+        onSoundToggle={toggleSound}
+        battleMode={battleMode}
+        onToggleLang={() => { window.SCOUTER_SFX?.play('click'); setLang(l => l === 'fr' ? 'en' : 'fr'); }}
+        onOpenThemes={() => { window.SCOUTER_SFX?.play('chirp'); setThemesOpen(true); }}
+      />
+
+      {themesOpen && (
+        <ThemesOverlay
+          lang={lang}
+          onClose={() => { window.SCOUTER_SFX?.play('click'); setThemesOpen(false); }}
+          onPick={(t) => {
+            window.SCOUTER_SFX?.play('click');
+            if (t.active) { setThemesOpen(false); return; }
+            if (t.route) {
+              localStorage.setItem('portfolio-theme', t.id);
+              window.location.href = t.route;
+              return;
+            }
+            setThemesOpen(false);
+          }}
+        />
+      )}
+
+      <button className="nav-btn prev" onClick={prev} disabled={sectionIdx === 0} aria-label="Previous">◀</button>
+      <button className="nav-btn next" onClick={next} disabled={sectionIdx === sectionCount - 1} aria-label="Next">▶</button>
+
+      <div className="deck" style={{ transform: `translateX(-${sectionIdx * 100}vw)` }}>
+
+        {/* 00 — Hero */}
+        <section className="panel">
+          <HeroLockOn
+            identity={data.identity}
+            heroStats={data.hero_stats}
+            lang={lang}
+            battleMode={battleMode}
+            toPowerLevel={toPowerLevel}
+            onToggleBattle={toggleBattle}
+          />
+        </section>
+
+        {/* 01 — Results */}
+        <section className="panel">
+          <header className="panel-head">
+            <span className="idx">{t.section_results}</span>
+            <h2 className="title">{t.title_results}</h2>
+            <span className="meta">{data.metrics.length} {t.records}</span>
+          </header>
+          {battleMode && (
+            <div className="alert-banner">
+              <span className="dot crimson blinker" />
+              <span className="msg">{lang === 'fr' ? 'NIVEAUX DE PUISSANCE DÉTECTÉS · > 9000' : 'POWER LEVELS DETECTED · > 9000'}</span>
+              <span className="num">◉◉◉</span>
+            </div>
+          )}
+          <div className="power-grid">
+            {data.metrics.map((m, i) => (
+              <PowerLevelCard key={i} metric={m} lang={lang} idx={i} battleMode={battleMode} toPowerLevel={toPowerLevel} />
+            ))}
+          </div>
+        </section>
+
+        {/* 02 — Skills */}
+        <section className="panel">
+          <header className="panel-head">
+            <span className="idx">{t.section_skills}</span>
+            <h2 className="title">{t.title_skills}</h2>
+            <span className="meta">{sortedSkills.length} {t.records}</span>
+          </header>
+          <div>
+            {sortedSkills.map((s, i) => (
+              <CombatStat key={i} skill={s} lang={lang} idx={i} battleMode={battleMode} toPowerLevel={toPowerLevel} />
+            ))}
+          </div>
+        </section>
+
+        {/* 03 — Field Reports */}
+        <section className="panel">
+          <header className="panel-head">
+            <span className="idx">{t.section_timeline}</span>
+            <h2 className="title">{t.title_timeline}</h2>
+            <span className="meta">{sortedExp.length} {t.records}</span>
+          </header>
+          <div>
+            {sortedExp.map((e, i) => <FieldReport key={e.id} exp={e} lang={lang} idx={i} />)}
+          </div>
+        </section>
+
+        {/* 04 — Certs */}
+        <section className="panel">
+          <header className="panel-head">
+            <span className="idx">{t.section_certs}</span>
+            <h2 className="title">{t.title_certs}</h2>
+            <span className="meta">{data.certifications.length} {t.records}</span>
+          </header>
+          <div className="rank-grid">
+            {data.certifications.map((c, i) => <RankInsignia key={i} cert={c} lang={lang} />)}
+          </div>
+        </section>
+
+        {/* 05 — Contact */}
+        <section className="panel">
+          <header className="panel-head">
+            <span className="idx">{t.section_contact}</span>
+            <h2 className="title">{t.title_contact}</h2>
+          </header>
+          <ContactBeacon contact={data.contact} lang={lang} />
+        </section>
+      </div>
+
+      {arrow && (
+        <NavArrow
+          direction={arrow.direction}
+          label={arrow.label}
+          sublabel={arrow.sublabel}
+          onDone={() => setArrow(null)}
+        />
+      )}
+
+      {/* keyboard hint, bottom-right */}
+      <div style={{
+        position: 'fixed', bottom: 16, right: 30, zIndex: 39,
+        fontFamily: 'var(--font-readout)', fontSize: 10,
+        letterSpacing: '0.22em', color: 'var(--fg-muted)',
+        textTransform: 'uppercase', pointerEvents: 'none'
+      }}>
+        ◀ ▶ keys · B = battle · L = lang · T = themes
+      </div>
+    </React.Fragment>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')).render(<App />);

--- a/scouter/colors_and_type.css
+++ b/scouter/colors_and_type.css
@@ -1,0 +1,338 @@
+/* ============================================================
+   SCOUTER HUD — Design Tokens (v2 · Ice Lens)
+   Sylvain VIZZINI portfolio · Nappa/Zarbon-style cockpit HUD
+   ============================================================ */
+
+/* --- WEBFONTS ----------------------------------------------- */
+/* All four come from Google Fonts. If you want to host locally,
+   drop .woff2 files into /fonts and swap these @imports for
+   @font-face declarations. */
+@import url('https://fonts.googleapis.com/css2?family=Saira+Stencil+One&family=Share+Tech+Mono&family=VT323&family=Orbitron:wght@500;700;900&family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  /* ============================================================
+     COLOR — Looking through tinted glass
+     ============================================================
+     The viewer wears a Saiyan-issue scouter, but not Vegeta's red
+     lens — Nappa's ice-blue / Zarbon's cyan. Everything reads off
+     a cool blue glass with violet accents. Four HUD tones drive
+     every readout:
+        ice (data)  ·  violet (secondary)  ·  amber (warning)  ·
+        crimson (alert / OVER 9000).
+     Behind the glass: deep navy void with saiyan-armor accents.
+  */
+
+  /* HUD ice — the cool blue glow of the scouter lens */
+  --hud-ice-100: #dceffa;
+  --hud-ice-300: #9fdbff;
+  --hud-ice:     #5cd6ff;   /* primary readout color */
+  --hud-ice-700: #1f8ed0;
+  --hud-ice-900: #0a4d80;
+  --hud-ice-glow: rgba(92, 214, 255, 0.55);
+  --hud-ice-dim:  rgba(92, 214, 255, 0.18);
+
+  /* HUD violet — secondary scale, hover, Nappa-pink accents */
+  --hud-violet-100: #ecd0ff;
+  --hud-violet:     #c77dff;
+  --hud-violet-700: #6b2d99;
+  --hud-violet-glow: rgba(199, 125, 255, 0.5);
+
+  /* HUD amber — secondary scale, marquees, side data */
+  --hud-amber-100: #fff1c2;
+  --hud-amber:     #ffc933;
+  --hud-amber-700: #cc8a00;
+  --hud-amber-glow: rgba(255, 201, 51, 0.45);
+
+  /* HUD crimson — high power level, danger, alert blinker */
+  --hud-crimson-100: #ffd2d6;
+  --hud-crimson:     #ff2238;
+  --hud-crimson-700: #9c0014;
+  --hud-crimson-glow: rgba(255, 34, 56, 0.55);
+
+  /* Lens chrome — the bezel that frames the screen */
+  --lens-chrome:      #4cd3ff;
+  --lens-chrome-glow: rgba(76, 211, 255, 0.45);
+
+  /* Backwards-compat aliases — old preview cards still load these */
+  --hud-phosphor-100: var(--hud-ice-100);
+  --hud-phosphor-300: var(--hud-ice-300);
+  --hud-phosphor:     var(--hud-ice);
+  --hud-phosphor-700: var(--hud-ice-700);
+  --hud-phosphor-900: var(--hud-ice-900);
+  --hud-phosphor-glow: var(--hud-ice-glow);
+  --hud-phosphor-dim:  var(--hud-ice-dim);
+  --lens-cyan: var(--lens-chrome);
+  --lens-cyan-glow: var(--lens-chrome-glow);
+
+  /* Vegeta armor palette — pulled from the saiyan prince's classic
+     ceremonial armor: royal navy plate, white spaulders, gold trim. */
+  --saiyan-navy:    #1a2772;
+  --saiyan-navy-deep: #0d143a;
+  --saiyan-white:   #f3f1e8;
+  --saiyan-gold:    #e8b339;
+  --saiyan-gold-deep: #8a6516;
+
+  /* Background — the deep-space void seen through the lens */
+  --void-100: #060914;   /* almost-black navy */
+  --void-200: #0a0f1f;
+  --void-300: #121831;
+  --void-400: #1a2348;
+  --void-line: rgba(92, 214, 255, 0.12);   /* hairline grid */
+  --void-line-strong: rgba(92, 214, 255, 0.32);
+
+  /* Semantic backgrounds */
+  --bg-page:    var(--void-100);
+  --bg-panel:   rgba(10, 15, 31, 0.78);
+  --bg-panel-strong: rgba(10, 15, 31, 0.92);
+  --bg-readout: rgba(92, 214, 255, 0.06);
+
+  /* Semantic foregrounds */
+  --fg-primary:   var(--hud-ice);
+  --fg-secondary: var(--hud-ice-300);
+  --fg-muted:     rgba(159, 219, 255, 0.55);
+  --fg-deemph:    rgba(159, 219, 255, 0.3);
+  --fg-onAlert:   var(--hud-crimson);
+  --fg-onWarn:    var(--hud-amber);
+
+  /* Borders & dividers */
+  --border-hairline: 1px solid var(--void-line);
+  --border-hud:      1px solid var(--hud-ice-700);
+  --border-hud-soft: 1px solid var(--hud-ice-dim);
+  --border-alert:    1px solid var(--hud-crimson-700);
+
+  /* Shadows & glows */
+  --glow-sm: 0 0 6px var(--hud-ice-glow);
+  --glow-md: 0 0 14px var(--hud-ice-glow);
+  --glow-lg: 0 0 32px var(--hud-ice-glow);
+  --glow-violet: 0 0 16px var(--hud-violet-glow);
+  --glow-alert: 0 0 18px var(--hud-crimson-glow);
+  --inner-readout: inset 0 0 18px rgba(92, 214, 255, 0.12);
+
+  /* ============================================================
+     TYPE — All-caps military telemetry stack
+     ============================================================
+     Two phosphor faces (VT323, Share Tech Mono) handle 95% of UI:
+     low-res chunky digits + cleaner mono labels. Saira Stencil One
+     does the saiyan-stenciled display headers. Inter survives as
+     the longform body-copy fallback for description prose.
+  */
+  --font-display:  'Saira Stencil One', 'Impact', 'Arial Black', sans-serif;
+  --font-hud:      'Orbitron', 'Eurostile', 'Bank Gothic', sans-serif;
+  --font-readout:  'Share Tech Mono', 'Consolas', monospace;
+  --font-digits:   'VT323', 'Courier New', monospace;
+  --font-body:     'Inter', system-ui, sans-serif;
+
+  /* Type scale */
+  --fs-12: 0.75rem;
+  --fs-14: 0.875rem;
+  --fs-16: 1rem;
+  --fs-18: 1.125rem;
+  --fs-24: 1.5rem;
+  --fs-32: 2rem;
+  --fs-48: 3rem;
+  --fs-64: 4rem;
+  --fs-96: 6rem;
+
+  /* Letter spacing */
+  --tracking-wide:    0.12em;   /* HUD labels */
+  --tracking-wider:   0.2em;    /* small-caps sublabels */
+  --tracking-widest:  0.32em;   /* section banner */
+  --tracking-tight:   -0.01em;  /* large digits */
+
+  /* Radii — the scouter has zero rounded corners.
+     Cards are hard chamfers via clip-path; only buttons get a
+     tiny radius. */
+  --radius-0:  0;
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+
+  /* Spacing scale — tight HUD grid, 4px base */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+  --sp-9: 96px;
+
+  /* Motion — terse, mechanical. Not springy. */
+  --ease-snap:  cubic-bezier(0.2, 0.9, 0.3, 1);
+  --ease-glide: cubic-bezier(0.4, 0, 0.2, 1);
+  --t-fast: 120ms;
+  --t-med:  220ms;
+  --t-slow: 420ms;
+}
+
+/* ============================================================
+   SEMANTIC TYPE CLASSES
+   ============================================================ */
+
+.t-banner {                         /* big stenciled section banner */
+  font-family: var(--font-display);
+  font-size: var(--fs-48);
+  letter-spacing: var(--tracking-wide);
+  color: var(--hud-phosphor);
+  text-transform: uppercase;
+  text-shadow: var(--glow-md);
+  line-height: 1;
+}
+
+.t-h1 {                              /* hero name */
+  font-family: var(--font-hud);
+  font-weight: 900;
+  font-size: var(--fs-96);
+  letter-spacing: var(--tracking-tight);
+  color: var(--hud-phosphor);
+  text-transform: uppercase;
+  text-shadow: var(--glow-lg);
+  line-height: 0.9;
+}
+
+.t-h2 {                              /* panel header */
+  font-family: var(--font-hud);
+  font-weight: 700;
+  font-size: var(--fs-32);
+  letter-spacing: var(--tracking-wide);
+  color: var(--hud-phosphor);
+  text-transform: uppercase;
+}
+
+.t-h3 {                              /* item title (e.g. company) */
+  font-family: var(--font-hud);
+  font-weight: 700;
+  font-size: var(--fs-18);
+  letter-spacing: var(--tracking-wide);
+  color: var(--hud-phosphor-100);
+  text-transform: uppercase;
+}
+
+.t-readout {                         /* monospace HUD label / sublabel */
+  font-family: var(--font-readout);
+  font-size: var(--fs-14);
+  letter-spacing: var(--tracking-wider);
+  color: var(--fg-secondary);
+  text-transform: uppercase;
+}
+
+.t-readout-sm {
+  font-family: var(--font-readout);
+  font-size: var(--fs-12);
+  letter-spacing: var(--tracking-wider);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+}
+
+.t-digits {                          /* the big power-level numbers */
+  font-family: var(--font-digits);
+  font-size: var(--fs-96);
+  color: var(--hud-amber);
+  text-shadow: 0 0 14px var(--hud-amber-glow);
+  line-height: 0.9;
+  letter-spacing: var(--tracking-tight);
+}
+
+.t-digits-md {
+  font-family: var(--font-digits);
+  font-size: var(--fs-48);
+  color: var(--hud-amber);
+  text-shadow: 0 0 8px var(--hud-amber-glow);
+  line-height: 1;
+}
+
+.t-body {                            /* longform prose */
+  font-family: var(--font-body);
+  font-size: var(--fs-16);
+  line-height: 1.55;
+  color: var(--fg-secondary);
+}
+
+.t-alert {                           /* crimson over-9000 alert text */
+  font-family: var(--font-hud);
+  font-weight: 900;
+  color: var(--hud-crimson);
+  text-shadow: var(--glow-alert);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-widest);
+}
+
+/* ============================================================
+   GLOBAL EFFECTS — Apply at body level for full-page lens look
+   ============================================================ */
+
+/* CRT scanlines — overlay on any panel via .has-scanlines */
+.has-scanlines {
+  position: relative;
+}
+.has-scanlines::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 2px,
+    rgba(0, 0, 0, 0.35) 3px,
+    transparent 4px
+  );
+  pointer-events: none;
+  z-index: 5;
+  mix-blend-mode: multiply;
+}
+
+/* Subtle horizontal flicker — apply to digit readouts for life */
+@keyframes hud-flicker {
+  0%, 92%, 100% { opacity: 1; }
+  93% { opacity: 0.72; }
+  95% { opacity: 0.95; }
+  97% { opacity: 0.6; }
+}
+.is-flickering { animation: hud-flicker 4.6s steps(1, end) infinite; }
+
+/* Scan beam — sweeps top to bottom on first reveal */
+@keyframes scan-beam {
+  0%   { transform: translateY(-100%); opacity: 0; }
+  20%  { opacity: 1; }
+  100% { transform: translateY(120vh); opacity: 0; }
+}
+.scan-beam {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: linear-gradient(to bottom, transparent, var(--hud-phosphor), transparent);
+  box-shadow: var(--glow-lg);
+  pointer-events: none;
+  z-index: 99;
+  animation: scan-beam 3.4s var(--ease-glide) infinite;
+}
+
+/* Lens vignette — radial darkening from edges so the "glass" feels round */
+.lens-vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse at center,
+      transparent 0%,
+      transparent 55%,
+      rgba(10, 14, 10, 0.65) 90%,
+      rgba(0, 0, 0, 0.95) 100%);
+  z-index: 60;
+}
+
+/* Bracket frame — the [ ] corners that mark targets / actionable items */
+.brackets {
+  position: relative;
+  padding: var(--sp-4);
+}
+.brackets::before,
+.brackets::after {
+  content: '';
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 2px solid var(--hud-phosphor);
+  filter: drop-shadow(0 0 4px var(--hud-phosphor-glow));
+}
+.brackets::before { top: 0; left: 0; border-right: none; border-bottom: none; }
+.brackets::after  { bottom: 0; right: 0; border-left: none; border-top: none; }

--- a/scouter/index.html
+++ b/scouter/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sylvain VIZZINI · Scouter HUD</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="colors_and_type.css">
+<link rel="stylesheet" href="scouter.css">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script src="sound.js"></script>
+  <script type="text/babel" src="LensOverlay.jsx"></script>
+  <script type="text/babel" src="ThemesOverlay.jsx"></script>
+  <script type="text/babel" src="Scouter.jsx"></script>
+  <script type="text/babel" src="HeroLockOn.jsx"></script>
+  <script type="text/babel" src="PowerLevelCard.jsx"></script>
+  <script type="text/babel" src="CombatStat.jsx"></script>
+  <script type="text/babel" src="FieldReport.jsx"></script>
+  <script type="text/babel" src="RankInsignia.jsx"></script>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/scouter/scouter.css
+++ b/scouter/scouter.css
@@ -1,0 +1,590 @@
+/* ============================================================
+   Scouter HUD v2 — Ice/Violet cockpit
+   Full curved lens overlay + horizontal section navigation
+   ============================================================ */
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  background: #020410;
+  color: var(--fg-primary);
+  font-family: var(--font-readout);
+  height: 100vh; width: 100vw;
+  overflow: hidden;   /* horizontal-nav: nothing scrolls outside */
+}
+
+body {
+  /* deep navy void with dot grid + center vignette */
+  background-image:
+    radial-gradient(rgba(92,214,255,0.10) 1px, transparent 1px),
+    radial-gradient(ellipse at center, transparent 0%, transparent 40%, rgba(2,4,16,0.7) 85%, #000 100%);
+  background-size: 18px 18px, 100% 100%;
+  background-attachment: fixed;
+}
+
+#app { position: relative; height: 100vh; width: 100vw; overflow: hidden; }
+
+/* ============================================================
+   THE LENS — full curved glass overlay
+   ============================================================ */
+.lens {
+  position: fixed; inset: 0; z-index: 30;
+  pointer-events: none;
+}
+.lens svg { width: 100%; height: 100%; display: block; }
+.lens .lens-rim { stroke: var(--lens-chrome); fill: none; }
+.lens .lens-tint {
+  /* faint cyan wash over the whole viewport, only inside the curve */
+  fill: url(#lens-tint-grad);
+}
+
+/* CRT scanlines inside the lens */
+.scanlines {
+  position: fixed; inset: 0; z-index: 32; pointer-events: none;
+  background-image: repeating-linear-gradient(to bottom,
+    transparent 0px, transparent 2px,
+    rgba(0,0,0,0.32) 3px, transparent 4px);
+  mix-blend-mode: multiply;
+}
+
+/* the sweeping scan beam */
+@keyframes scan-beam {
+  0% { transform: translateY(-10vh); opacity: 0; }
+  10% { opacity: 1; }
+  100% { transform: translateY(110vh); opacity: 0; }
+}
+.scan-beam {
+  position: fixed; left: 0; right: 0; top: 0; height: 3px; z-index: 34;
+  background: linear-gradient(to bottom, transparent, var(--hud-ice) 50%, transparent);
+  box-shadow: 0 0 24px var(--hud-ice-glow), 0 0 60px var(--hud-ice-glow);
+  pointer-events: none;
+  animation: scan-beam 5.2s linear infinite;
+}
+
+/* push violet harder — chromatic aberration tint, prominent */
+.lens-aberration {
+  position: fixed; inset: 0; z-index: 31; pointer-events: none;
+  background:
+    radial-gradient(circle at 88% 14%, rgba(92,214,255,0.18), transparent 42%),
+    radial-gradient(circle at 12% 88%, rgba(199,125,255,0.22), transparent 45%),
+    radial-gradient(circle at 14% 18%, rgba(199,125,255,0.10), transparent 35%);
+  mix-blend-mode: screen;
+}
+
+/* ============================================================
+   COCKPIT CHROME — top status bar + bottom telemetry + corners
+   ============================================================ */
+.chrome { position: fixed; inset: 0; z-index: 36; pointer-events: none; }
+.chrome > * { pointer-events: auto; }
+
+.chrome-bar {
+  position: absolute; left: 0; right: 0;
+  display: flex; align-items: center; gap: var(--sp-5);
+  padding: var(--sp-3) var(--sp-5);
+  font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-wider); text-transform: uppercase;
+  color: var(--hud-ice);
+  background: linear-gradient(180deg, rgba(6,9,20,0.92), rgba(6,9,20,0.5));
+  border-bottom: 1px solid var(--hud-ice-900);
+}
+.chrome-bar.bot {
+  top: auto; bottom: 0;
+  background: linear-gradient(0deg, rgba(6,9,20,0.92), rgba(6,9,20,0.5));
+  border-top: 1px solid var(--hud-ice-900);
+  border-bottom: none;
+}
+
+.chrome-bar .sep { color: var(--fg-deemph); }
+.chrome-bar .grow { flex: 1; }
+.chrome-bar strong { color: var(--hud-ice-100); font-weight: 700; }
+
+.dot { width: 8px; height: 8px; border-radius: 50%; background: var(--hud-ice); box-shadow: 0 0 8px var(--hud-ice-glow); display: inline-block; }
+.dot.amber   { background: var(--hud-amber);   box-shadow: 0 0 8px var(--hud-amber-glow); }
+.dot.crimson { background: var(--hud-crimson); box-shadow: 0 0 10px var(--hud-crimson-glow); }
+.dot.violet  { background: var(--hud-violet);  box-shadow: 0 0 10px var(--hud-violet-glow); }
+
+@keyframes blink-fast { 0%,49%,100%{opacity:1} 50%,99%{opacity:.2} }
+@keyframes blink-slow { 0%,79%,100%{opacity:1} 80%,99%{opacity:.35} }
+.blinker { animation: blink-fast 0.9s steps(1,end) infinite; }
+.blinker-slow { animation: blink-slow 1.8s steps(1,end) infinite; }
+
+/* small fixed gauge ARC along the bottom lens curve */
+.gauge-arc {
+  position: absolute; bottom: 56px; left: 50%; transform: translateX(-50%);
+  display: flex; gap: var(--sp-3);
+  pointer-events: auto;
+}
+.gauge-arc .gauge-wrap { display: block; transform: translateY(var(--dip, 0px)); }
+
+.gauge {
+  width: 88px; padding: 6px 8px;
+  background: rgba(10,15,31,0.85);
+  border: 1px solid var(--hud-ice-700);
+  box-shadow: inset 0 0 12px rgba(92,214,255,0.15);
+  font-family: var(--font-readout); font-size: 9px;
+  letter-spacing: var(--tracking-wider); text-transform: uppercase;
+  color: var(--hud-ice-300);
+}
+.gauge .v {
+  font-family: var(--font-digits); font-size: 22px;
+  color: var(--hud-amber); line-height: 1; text-shadow: 0 0 6px var(--hud-amber-glow);
+  margin-top: 2px;
+}
+.gauge.alert .v { color: var(--hud-crimson); text-shadow: 0 0 8px var(--hud-crimson-glow); }
+.gauge.violet .v { color: var(--hud-violet); text-shadow: 0 0 6px var(--hud-violet-glow); }
+
+/* big corner brackets removed for immersion */
+
+/* center crosshair when idle */
+.crosshair {
+  position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: 220px; height: 220px;
+  pointer-events: none; opacity: 0.08; z-index: 33;
+}
+
+/* ============================================================
+   HORIZONTAL SECTION NAVIGATION
+   ============================================================ */
+.deck {
+  position: absolute; top: 60px; bottom: 60px;
+  left: 0; width: 100vw;
+  display: flex;
+  transition: transform 520ms var(--ease-glide);
+  will-change: transform;
+}
+.deck.swiping { transition: transform 360ms cubic-bezier(0.5, 0, 0.5, 1); }
+
+.panel {
+  flex: 0 0 100vw; height: 100%;
+  padding: var(--sp-7) clamp(80px, 9vw, 160px);
+  overflow-y: auto; overflow-x: hidden;
+  position: relative;
+}
+.panel::-webkit-scrollbar { width: 8px; }
+.panel::-webkit-scrollbar-track { background: rgba(10,15,31,0.5); }
+.panel::-webkit-scrollbar-thumb { background: var(--hud-ice-700); }
+
+.panel-head {
+  display: flex; align-items: baseline; gap: var(--sp-5);
+  margin-bottom: var(--sp-6);
+  padding-bottom: var(--sp-3);
+  border-bottom: 1px dashed var(--void-line-strong);
+}
+.panel-head .idx {
+  font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-widest); color: var(--hud-violet);
+  padding: 4px 8px; border: 1px solid var(--hud-violet-700);
+  background: rgba(107,45,153,0.18);
+}
+.panel-head .title {
+  font-family: var(--font-display); font-size: clamp(36px, 4.5vw, 56px);
+  letter-spacing: 0.08em; color: var(--hud-ice);
+  text-shadow: var(--glow-md); text-transform: uppercase;
+  line-height: 1;
+}
+.panel-head .meta {
+  margin-left: auto; font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-wider); color: var(--fg-muted);
+  display: flex; gap: var(--sp-3); align-items: center;
+}
+
+/* ============================================================
+   DIRECTIONAL ARROW — flashes during nav transitions
+   ============================================================ */
+@keyframes arrow-flash {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.7); }
+  20%  { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  70%  { opacity: 1; }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(1.1); }
+}
+.nav-arrow {
+  position: fixed; top: 50%; left: 50%; z-index: 90;
+  pointer-events: none;
+  animation: arrow-flash 720ms var(--ease-snap) forwards;
+  display: flex; align-items: center; gap: var(--sp-4);
+  background: rgba(6,9,20,0.85);
+  border: 2px solid var(--hud-crimson);
+  padding: var(--sp-3) var(--sp-5);
+  box-shadow: var(--glow-alert), inset 0 0 18px rgba(255,34,56,0.2);
+}
+.nav-arrow .chevron {
+  font-family: var(--font-hud); font-weight: 900; font-size: 64px;
+  color: var(--hud-crimson); text-shadow: var(--glow-alert);
+  line-height: 1;
+}
+.nav-arrow .lbl {
+  display: flex; flex-direction: column; gap: 4px;
+  font-family: var(--font-hud); font-weight: 900; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--hud-crimson);
+  text-shadow: var(--glow-alert);
+}
+.nav-arrow .lbl .small {
+  font-family: var(--font-readout); font-size: 11px;
+  letter-spacing: 0.3em; color: var(--hud-amber);
+}
+.nav-arrow .lbl .big { font-size: 22px; }
+.nav-arrow.left { flex-direction: row-reverse; }
+.nav-arrow.left .chevron::before { content: '◀'; }
+.nav-arrow.right .chevron::before { content: '▶'; }
+
+/* ============================================================
+   NAV BUTTONS at edges of lens — prev/next
+   ============================================================ */
+.nav-btn {
+  position: fixed; top: 50%; transform: translateY(-50%);
+  z-index: 38; pointer-events: auto;
+  width: 56px; height: 96px;
+  background: rgba(6,9,20,0.7);
+  border: 1px solid var(--hud-ice-700);
+  color: var(--hud-ice);
+  font-family: var(--font-hud); font-weight: 900; font-size: 28px;
+  cursor: pointer;
+  display: grid; place-items: center;
+  transition: all 120ms var(--ease-snap);
+  box-shadow: inset 0 0 16px rgba(92,214,255,0.18);
+}
+.nav-btn:hover { background: rgba(92,214,255,0.12); color: var(--hud-amber); border-color: var(--hud-amber); box-shadow: inset 0 0 16px var(--hud-amber-glow), 0 0 14px var(--hud-amber-glow); }
+.nav-btn:disabled { opacity: 0.25; cursor: not-allowed; }
+.nav-btn.prev { left: 24px; }
+.nav-btn.next { right: 24px; }
+
+/* section indicator dots in top bar */
+.section-indicator { display: flex; gap: var(--sp-2); align-items: center; }
+.section-indicator .si {
+  width: 28px; height: 4px; background: var(--hud-ice-700); opacity: 0.4;
+  cursor: pointer; transition: all 120ms var(--ease-snap);
+}
+.section-indicator .si.active {
+  background: var(--hud-amber); opacity: 1; box-shadow: 0 0 8px var(--hud-amber-glow);
+}
+.section-indicator .si:hover { opacity: 1; }
+
+/* ============================================================
+   HERO PANEL
+   ============================================================ */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-7); align-items: center;
+  height: 100%;
+}
+@media (max-width: 1100px) {
+  .hero-grid { grid-template-columns: 1fr; gap: var(--sp-5); }
+}
+
+.hero-text .preamble {
+  display: flex; align-items: center; gap: var(--sp-3);
+  font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-widest); color: var(--hud-ice-300);
+  text-transform: uppercase; margin-bottom: var(--sp-4);
+}
+.hero-text .name {
+  font-family: var(--font-hud); font-weight: 900;
+  font-size: clamp(56px, 7.5vw, 112px); line-height: 0.86;
+  color: var(--hud-ice);
+  letter-spacing: -0.02em; text-transform: uppercase;
+  text-shadow: 0 0 24px var(--hud-ice-glow), 0 0 60px var(--hud-ice-glow);
+}
+.hero-text .name .sep { color: var(--saiyan-gold); }
+.hero-text .role {
+  font-family: var(--font-hud); font-weight: 700;
+  font-size: clamp(14px, 1.4vw, 20px);
+  color: var(--hud-amber); letter-spacing: var(--tracking-wide);
+  text-transform: uppercase; margin-top: var(--sp-4);
+  text-shadow: 0 0 8px var(--hud-amber-glow);
+}
+.hero-text .tagline {
+  font-family: var(--font-readout); font-size: clamp(16px, 1.4vw, 22px);
+  color: var(--hud-ice-100); max-width: 560px;
+  margin-top: var(--sp-4); line-height: 1.35;
+  letter-spacing: 0.04em;
+}
+.hero-text .tagline::before { content: '> '; color: var(--hud-ice); }
+.hero-text .tagline::after { content: ' _'; animation: blink-slow 1.2s steps(1,end) infinite; color: var(--hud-amber); }
+
+.hero-stats-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-4);
+}
+.stat-cell {
+  position: relative; padding: var(--sp-5);
+  background: rgba(10,15,31,0.85);
+  border: 1px solid var(--hud-ice-dim);
+  box-shadow: inset 0 0 18px rgba(92,214,255,0.12);
+  min-height: 150px;
+  clip-path: polygon(0 0, calc(100% - 16px) 0, 100% 16px, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+  transition: all 220ms var(--ease-glide);
+}
+.stat-cell:hover { border-color: var(--hud-amber); box-shadow: inset 0 0 22px var(--hud-amber-glow); }
+.stat-cell .stat-id {
+  font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-widest); color: var(--fg-muted);
+}
+.stat-cell .stat-val {
+  font-family: var(--font-digits); font-size: 64px;
+  color: var(--hud-amber); text-shadow: 0 0 12px var(--hud-amber-glow);
+  line-height: 1; margin-top: var(--sp-3);
+}
+.stat-cell .stat-val.hot { color: var(--hud-crimson); text-shadow: 0 0 14px var(--hud-crimson-glow); }
+.stat-cell .stat-lbl {
+  font-family: var(--font-readout); font-size: var(--fs-12);
+  letter-spacing: var(--tracking-wider); color: var(--hud-ice-300);
+  text-transform: uppercase; margin-top: var(--sp-3); line-height: 1.4;
+}
+
+/* power-level mode badge in hero */
+.battle-toggle {
+  display: inline-flex; align-items: center; gap: var(--sp-3);
+  margin-top: var(--sp-5);
+  padding: var(--sp-3) var(--sp-4);
+  background: rgba(107,45,153,0.18);
+  border: 1px solid var(--hud-violet);
+  color: var(--hud-violet-100);
+  font-family: var(--font-hud); font-weight: 700; font-size: 12px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  cursor: pointer;
+  transition: all 120ms var(--ease-snap);
+}
+.battle-toggle:hover { background: var(--hud-violet); color: var(--void-100); box-shadow: var(--glow-violet); }
+.battle-toggle.on { background: var(--hud-crimson); border-color: var(--hud-crimson); color: var(--saiyan-white); box-shadow: var(--glow-alert); animation: blink-slow 1.8s steps(1,end) infinite; }
+
+/* ============================================================
+   BUTTONS
+   ============================================================ */
+.btn {
+  font-family: var(--font-hud); font-weight: 700; font-size: var(--fs-12);
+  letter-spacing: var(--tracking-wide); text-transform: uppercase;
+  padding: var(--sp-3) var(--sp-5); background: transparent;
+  border: 1px solid var(--hud-ice-700); color: var(--hud-ice);
+  border-radius: var(--radius-xs); cursor: pointer;
+  text-decoration: none; display: inline-flex; align-items: center; gap: var(--sp-3);
+  transition: all 120ms var(--ease-snap); position: relative;
+}
+.btn:hover { color: var(--hud-amber); border-color: var(--hud-amber); box-shadow: 0 0 14px var(--hud-amber-glow); }
+.btn:active { transform: translateY(1px); }
+.btn.primary { background: var(--hud-ice); color: var(--void-100); border-color: var(--hud-ice); box-shadow: 0 0 14px var(--hud-ice-glow); }
+.btn.primary:hover { background: var(--hud-amber); border-color: var(--hud-amber); }
+.btn::before { content: '['; margin-right: 2px; opacity: 0.6; }
+.btn::after  { content: ']'; margin-left: 2px; opacity: 0.6; }
+
+.btn-row { display: flex; gap: var(--sp-3); flex-wrap: wrap; margin-top: var(--sp-5); }
+
+/* ============================================================
+   POWER CARDS (Results panel)
+   ============================================================ */
+.power-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-4); }
+@media (max-width: 1200px) { .power-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 700px)  { .power-grid { grid-template-columns: 1fr; } }
+
+.power-card {
+  position: relative; padding: var(--sp-5);
+  background: rgba(10,15,31,0.85);
+  border: 1px solid var(--hud-ice-dim);
+  box-shadow: inset 0 0 22px rgba(92,214,255,0.10);
+  min-height: 250px; display: flex; flex-direction: column;
+  transition: all 220ms var(--ease-glide);
+}
+.power-card:hover { border-color: var(--hud-violet); box-shadow: inset 0 0 26px rgba(199,125,255,0.22), 0 0 16px var(--hud-violet-glow); transform: translateY(-2px); }
+.power-card .pc-head { display: flex; justify-content: space-between; align-items: flex-start; }
+.power-card .pc-id { font-family: var(--font-readout); font-size: var(--fs-12); letter-spacing: var(--tracking-widest); color: var(--hud-violet); }
+.power-card .pc-val { font-family: var(--font-digits); font-size: 76px; color: var(--hud-amber); line-height: 0.9; margin: var(--sp-3) 0; text-shadow: 0 0 14px var(--hud-amber-glow); }
+.power-card .pc-val.hot { color: var(--hud-crimson); text-shadow: 0 0 18px var(--hud-crimson-glow); }
+.power-card .pc-val.battle { color: var(--hud-crimson); text-shadow: 0 0 22px var(--hud-crimson-glow); font-size: 64px; }
+.power-card .pc-lbl { font-family: var(--font-hud); font-weight: 700; font-size: var(--fs-16); letter-spacing: var(--tracking-wide); color: var(--hud-ice-100); text-transform: uppercase; }
+.power-card .pc-desc { font-family: var(--font-body); font-size: var(--fs-14); color: var(--hud-ice-300); margin-top: var(--sp-3); line-height: 1.5; flex: 1; }
+.power-card .pc-src { font-family: var(--font-readout); font-size: var(--fs-12); letter-spacing: var(--tracking-wider); color: var(--saiyan-gold); text-transform: uppercase; margin-top: var(--sp-4); }
+.power-card .pc-src::before { content: '◉ '; }
+.power-card .reticle { width: 32px; height: 32px; opacity: 0.75; filter: hue-rotate(180deg) saturate(1.4); }
+
+/* alert banner */
+.alert-banner {
+  display: flex; align-items: center; gap: var(--sp-5);
+  padding: var(--sp-4) var(--sp-5);
+  border: 1px solid var(--hud-crimson-700);
+  background: linear-gradient(90deg, rgba(60,0,8,0.5), rgba(6,9,20,0.3));
+  box-shadow: var(--glow-alert);
+  margin-bottom: var(--sp-5);
+}
+.alert-banner .msg { font-family: var(--font-hud); font-weight: 900; font-size: var(--fs-16); letter-spacing: var(--tracking-widest); color: var(--hud-crimson); text-transform: uppercase; }
+.alert-banner .num { font-family: var(--font-digits); font-size: var(--fs-32); color: var(--hud-crimson); margin-left: auto; text-shadow: var(--glow-alert); }
+
+/* ============================================================
+   COMBAT STATS (skills)
+   ============================================================ */
+.combat-stat { display: grid; grid-template-columns: 1.3fr 2fr 0.5fr; gap: var(--sp-4); align-items: center; padding: var(--sp-3) 0; border-bottom: 1px dashed var(--void-line); }
+.combat-stat .name { font-family: var(--font-hud); font-weight: 700; font-size: var(--fs-14); letter-spacing: var(--tracking-wide); color: var(--hud-ice-100); text-transform: uppercase; }
+.combat-stat .bar { position: relative; height: 18px; background: rgba(92,214,255,0.06); border: 1px solid var(--hud-ice-dim); overflow: hidden; }
+.combat-stat .fill { height: 100%; background: linear-gradient(to right, var(--hud-ice-700), var(--hud-amber)); box-shadow: 0 0 10px var(--hud-amber-glow); position: relative; transition: width 1.2s var(--ease-glide); }
+.combat-stat .fill::after { content:''; position:absolute; inset:0; background: repeating-linear-gradient(90deg, transparent 0 6px, rgba(0,0,0,0.35) 6px 8px); }
+.combat-stat .fill.hot { background: linear-gradient(to right, var(--hud-ice), var(--hud-crimson)); box-shadow: 0 0 12px var(--hud-crimson-glow); }
+.combat-stat .pct { font-family: var(--font-digits); font-size: var(--fs-32); color: var(--hud-amber); text-align: right; line-height: 1; }
+.combat-stat .pct.hot { color: var(--hud-crimson); text-shadow: 0 0 8px var(--hud-crimson-glow); }
+.combat-stat:nth-child(even) .name { color: var(--hud-violet-100); }
+.combat-stat:hover .name { color: var(--hud-amber); }
+
+/* ============================================================
+   FIELD REPORTS (timeline)
+   ============================================================ */
+.report {
+  position: relative; padding: var(--sp-5);
+  background: rgba(10,15,31,0.85);
+  border: 1px solid var(--hud-ice-dim);
+  box-shadow: inset 0 0 22px rgba(92,214,255,0.08);
+  margin-bottom: var(--sp-4);
+  transition: all 220ms var(--ease-glide);
+}
+.report:hover { border-color: var(--hud-violet); box-shadow: inset 0 0 22px rgba(199,125,255,0.18), 0 0 14px var(--hud-violet-glow); }
+.report::before, .report::after {
+  content: ''; position: absolute; width: 18px; height: 18px;
+  border: 2px solid var(--hud-ice);
+  filter: drop-shadow(0 0 4px var(--hud-ice-glow));
+}
+.report::before { top: -1px; left: -1px; border-right: none; border-bottom: none; }
+.report::after  { bottom: -1px; right: -1px; border-left: none; border-top: none; }
+.report .head { display: flex; justify-content: space-between; align-items: flex-start; gap: var(--sp-4); }
+.report .id   { font-family: var(--font-readout); font-size: var(--fs-12); letter-spacing: var(--tracking-widest); color: var(--hud-violet); }
+.report .role { font-family: var(--font-hud); font-weight: 800; font-size: var(--fs-18); letter-spacing: 0.08em; color: var(--hud-ice-100); text-transform: uppercase; margin-top: var(--sp-2); }
+.report .company { font-family: var(--font-readout); font-size: var(--fs-14); letter-spacing: var(--tracking-wider); color: var(--hud-amber); text-transform: uppercase; }
+.report .meta { font-family: var(--font-readout); font-size: var(--fs-12); letter-spacing: var(--tracking-wider); color: var(--fg-muted); margin-top: var(--sp-1); }
+.report .desc { font-family: var(--font-body); font-size: var(--fs-14); color: var(--hud-ice-300); line-height: 1.55; margin-top: var(--sp-3); }
+.report .tags { display: flex; flex-wrap: wrap; gap: var(--sp-2); margin-top: var(--sp-3); }
+.report .tag { font-family: var(--font-readout); font-size: 11px; letter-spacing: var(--tracking-wide); padding: 3px 7px; border: 1px solid var(--hud-ice-dim); background: rgba(92,214,255,0.05); color: var(--hud-ice-300); text-transform: uppercase; }
+.report .reticle { width: 32px; height: 32px; opacity: 0.85; filter: hue-rotate(180deg) saturate(1.4); }
+.report.current::before, .report.current::after { border-color: var(--hud-crimson); filter: drop-shadow(0 0 6px var(--hud-crimson-glow)); }
+.report.current .id { color: var(--hud-crimson); }
+.report.current .role { color: var(--hud-crimson-100); }
+
+/* ============================================================
+   RANK INSIGNIA (certs)
+   ============================================================ */
+.rank-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-4); }
+@media (max-width: 900px) { .rank-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 540px) { .rank-grid { grid-template-columns: 1fr; } }
+.rank {
+  position: relative; padding: var(--sp-4);
+  border: 1px solid var(--saiyan-gold-deep);
+  background: linear-gradient(135deg, rgba(26,39,114,0.55), rgba(13,20,58,0.7));
+  display: flex; gap: var(--sp-4); align-items: center;
+  transition: all 220ms var(--ease-glide);
+}
+.rank:hover { border-color: var(--saiyan-gold); box-shadow: 0 0 16px rgba(232,179,57,0.45); transform: translateY(-2px); }
+.rank .badge {
+  width: 52px; height: 52px; flex-shrink: 0;
+  display: grid; place-items: center;
+  border: 2px solid var(--saiyan-gold);
+  transform: rotate(45deg);
+  background: var(--saiyan-navy-deep);
+  box-shadow: 0 0 14px rgba(232,179,57,0.4);
+}
+.rank .badge span {
+  transform: rotate(-45deg);
+  font-family: var(--font-hud); font-weight: 900; font-size: 12px;
+  color: var(--saiyan-gold); letter-spacing: 0.05em;
+  text-align: center; line-height: 1;
+}
+.rank .info .year { font-family: var(--font-digits); font-size: var(--fs-24); color: var(--saiyan-gold); line-height: 1; }
+.rank .info .name { font-family: var(--font-hud); font-weight: 700; font-size: var(--fs-14); letter-spacing: var(--tracking-wide); color: var(--hud-ice-100); text-transform: uppercase; margin: var(--sp-1) 0; }
+.rank .info .org  { font-family: var(--font-readout); font-size: 11px; letter-spacing: var(--tracking-wider); color: var(--fg-muted); text-transform: uppercase; }
+
+/* ============================================================
+   CONTACT BEACON
+   ============================================================ */
+.beacon {
+  position: relative; padding: var(--sp-8) var(--sp-7);
+  text-align: center;
+  background: radial-gradient(ellipse at center, rgba(26,39,114,0.55), rgba(6,9,20,0.9));
+  border: 1px solid var(--hud-ice-700);
+  box-shadow: var(--glow-md), inset 0 0 40px rgba(92,214,255,0.15);
+}
+.beacon .beacon-id { font-family: var(--font-readout); font-size: var(--fs-12); letter-spacing: var(--tracking-widest); color: var(--hud-crimson); text-transform: uppercase; }
+.beacon h2 { font-family: var(--font-display); font-size: clamp(40px, 5vw, 64px); color: var(--hud-ice); text-shadow: var(--glow-lg); margin: var(--sp-4) 0; letter-spacing: 0.08em; }
+.beacon p { font-family: var(--font-readout); font-size: var(--fs-18); letter-spacing: var(--tracking-wide); color: var(--hud-ice-100); text-transform: uppercase; }
+.beacon .btn-row { justify-content: center; }
+
+/* ============================================================
+   BOOT SCREEN
+   ============================================================ */
+.bootscreen {
+  position: fixed; inset: 0; z-index: 100;
+  background: #020410;
+  display: grid; place-items: center;
+  font-family: var(--font-readout); color: var(--hud-ice);
+}
+.bootscreen .lines { width: min(640px, 84vw); }
+.bootscreen .line { display: flex; gap: var(--sp-3); margin: var(--sp-2) 0; font-size: var(--fs-14); letter-spacing: var(--tracking-wide); text-transform: uppercase; opacity: 0; animation: bootfade 0.2s steps(1, end) forwards; }
+@keyframes bootfade { to { opacity: 1; } }
+.bootscreen .line .ok { color: var(--hud-amber); }
+.bootscreen .crest { width: 96px; height: 96px; margin: 0 auto var(--sp-5); animation: blink-slow 0.8s steps(1,end) infinite; filter: hue-rotate(190deg) saturate(0.7); }
+.bootscreen.dismissed { animation: bootout 0.4s var(--ease-snap) forwards; }
+@keyframes bootout { to { opacity: 0; pointer-events: none; } }
+
+/* ============================================================
+   THEMES PICKER overlay (mirrors live-site theme switcher)
+   ============================================================ */
+.themes-overlay {
+  position: fixed; inset: 0; z-index: 95;
+  background: rgba(2, 4, 16, 0.86);
+  display: grid; place-items: center;
+  animation: fadein 0.25s var(--ease-snap);
+}
+@keyframes fadein { from { opacity: 0; } to { opacity: 1; } }
+.themes-panel {
+  background: rgba(10,15,31,0.95);
+  border: 1px solid var(--hud-violet);
+  padding: var(--sp-7);
+  box-shadow: var(--glow-violet), inset 0 0 30px rgba(199,125,255,0.15);
+  max-width: 720px; width: 90vw;
+  position: relative;
+}
+.themes-panel h3 {
+  font-family: var(--font-display); font-size: var(--fs-32); letter-spacing: 0.08em;
+  color: var(--hud-ice); text-transform: uppercase; text-shadow: var(--glow-md);
+  margin-bottom: var(--sp-2);
+}
+.themes-panel .sub {
+  font-family: var(--font-readout); font-size: 11px; letter-spacing: 0.22em;
+  color: var(--hud-violet); text-transform: uppercase; margin-bottom: var(--sp-5);
+}
+.themes-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--sp-3); }
+@media (max-width: 640px) { .themes-grid { grid-template-columns: repeat(2, 1fr); } }
+.theme-card {
+  padding: var(--sp-4) var(--sp-3);
+  border: 1px solid var(--hud-ice-dim);
+  background: rgba(6,9,20,0.6);
+  text-align: center;
+  font-family: var(--font-hud); font-weight: 700; font-size: 12px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--hud-ice-300);
+  cursor: pointer; transition: all 120ms var(--ease-snap);
+  position: relative; min-height: 84px;
+  display: flex; flex-direction: column; gap: 6px; align-items: center; justify-content: center;
+}
+.theme-card:hover:not(.disabled) { border-color: var(--hud-amber); color: var(--hud-amber); box-shadow: 0 0 14px var(--hud-amber-glow); }
+.theme-card.active { border-color: var(--hud-ice); background: rgba(92,214,255,0.12); color: var(--hud-ice); box-shadow: 0 0 14px var(--hud-ice-glow); }
+.theme-card.disabled { opacity: 0.4; cursor: not-allowed; }
+.theme-card .badge { font-family: var(--font-readout); font-size: 9px; letter-spacing: 0.22em; padding: 1px 5px; border: 1px solid currentColor; color: var(--fg-muted); }
+.theme-card.active .badge { color: var(--hud-amber); border-color: var(--hud-amber); }
+.themes-close {
+  position: absolute; top: var(--sp-3); right: var(--sp-3);
+  width: 28px; height: 28px; background: transparent;
+  border: 1px solid var(--hud-ice-700); color: var(--hud-ice);
+  font-family: var(--font-hud); font-size: 18px; cursor: pointer;
+  line-height: 1;
+}
+.themes-close:hover { color: var(--hud-crimson); border-color: var(--hud-crimson); }
+
+/* ============================================================
+   TOP-BAR INTERACTIVE BUTTONS
+   ============================================================ */
+.bar-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--hud-ice-700);
+  color: var(--hud-ice);
+  font-family: var(--font-readout); font-size: 11px;
+  letter-spacing: var(--tracking-wider); text-transform: uppercase;
+  cursor: pointer; transition: all 120ms var(--ease-snap);
+}
+.bar-btn:hover { color: var(--hud-amber); border-color: var(--hud-amber); }
+.bar-btn.violet { border-color: var(--hud-violet); color: var(--hud-violet); }
+.bar-btn.violet:hover { color: var(--saiyan-white); background: var(--hud-violet); border-color: var(--hud-violet); box-shadow: var(--glow-violet); }
+.bar-btn .dot { width: 6px; height: 6px; }

--- a/scouter/sound.js
+++ b/scouter/sound.js
@@ -1,0 +1,53 @@
+// Lightweight Web Audio cockpit sounds — no library, no assets.
+// All beeps are short oscillator burts at canonical 80s console tones.
+
+(function () {
+  let ctx = null;
+  let enabled = (localStorage.getItem('scouter-sound') ?? '1') === '1';
+
+  function getCtx() {
+    if (!ctx) {
+      try { ctx = new (window.AudioContext || window.webkitAudioContext)(); }
+      catch (e) { return null; }
+    }
+    if (ctx.state === 'suspended') ctx.resume();
+    return ctx;
+  }
+
+  function tone({ freq = 880, dur = 0.08, type = 'square', vol = 0.05, slide = 0, delay = 0 }) {
+    if (!enabled) return;
+    const c = getCtx();
+    if (!c) return;
+    const t0 = c.currentTime + delay;
+    const osc = c.createOscillator();
+    const gain = c.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t0);
+    if (slide) osc.frequency.exponentialRampToValueAtTime(Math.max(40, freq + slide), t0 + dur);
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(vol, t0 + 0.005);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+    osc.connect(gain).connect(c.destination);
+    osc.start(t0);
+    osc.stop(t0 + dur + 0.02);
+  }
+
+  const SFX = {
+    beep:      () => tone({ freq: 1320, dur: 0.05, type: 'square', vol: 0.05 }),
+    hover:     () => tone({ freq: 880,  dur: 0.04, type: 'triangle', vol: 0.03 }),
+    click:     () => { tone({ freq: 1760, dur: 0.05, type: 'square', vol: 0.06 }); tone({ freq: 880, dur: 0.05, type: 'square', vol: 0.04, delay: 0.05 }); },
+    next:      () => { tone({ freq: 660, dur: 0.06, type: 'sawtooth', vol: 0.05, slide: 600 }); tone({ freq: 1260, dur: 0.08, type: 'square', vol: 0.04, delay: 0.06 }); },
+    prev:      () => { tone({ freq: 1260, dur: 0.06, type: 'sawtooth', vol: 0.05, slide: -600 }); tone({ freq: 660, dur: 0.08, type: 'square', vol: 0.04, delay: 0.06 }); },
+    powerup:   () => { for (let i = 0; i < 6; i++) tone({ freq: 440 + i * 220, dur: 0.07, type: 'square', vol: 0.05, delay: i * 0.06 }); },
+    powerdown: () => { for (let i = 0; i < 5; i++) tone({ freq: 1320 - i * 220, dur: 0.07, type: 'square', vol: 0.04, delay: i * 0.05 }); },
+    alert:     () => { tone({ freq: 2200, dur: 0.05, type: 'square', vol: 0.06 }); tone({ freq: 2200, dur: 0.05, type: 'square', vol: 0.06, delay: 0.1 }); },
+    boot:      () => { for (let i = 0; i < 8; i++) tone({ freq: 220 + Math.random() * 880, dur: 0.04, type: 'triangle', vol: 0.025, delay: i * 0.08 }); },
+    chirp:     () => tone({ freq: 1760, dur: 0.06, type: 'square', vol: 0.04, slide: 1200 })
+  };
+
+  window.SCOUTER_SFX = {
+    play: (name) => { try { SFX[name] && SFX[name](); } catch (e) {} },
+    enabled: () => enabled,
+    set: (v) => { enabled = !!v; localStorage.setItem('scouter-sound', enabled ? '1' : '0'); }
+  };
+})();


### PR DESCRIPTION
## Summary
- Add the DBZ Scouter theme as a parallel `scouter/` route
- Wire the landing page Dragon Ball Z button to the new route
- Add Scouter assets, internal theme switching, and mini-lens landing button styling

## Verification
- Served locally at `http://127.0.0.1:8080`
- Verified `/`, `/scouter/index.html`, `/career.json`, and copied SVG assets return `200`