### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+## 2026-05-26 - Reverse Tabnabbing Vulnerability
+**Vulnerability:** External links opening in new tabs (`target="_blank"`) lacked the `rel="noopener noreferrer"` attribute in both Vanilla JS template literals and React JSX components.
+**Learning:** This vulnerability pattern existed because external links were dynamically generated or hardcoded without explicit security attributes, potentially allowing the newly opened tab to manipulate the original tab's  object.
+**Prevention:** Always include `rel="noopener noreferrer"` on any `<a>` tag that uses `target="_blank"`.
+## 2026-05-26 - Reverse Tabnabbing Vulnerability
+**Vulnerability:** External links opening in new tabs (`target="_blank"`) lacked the `rel="noopener noreferrer"` attribute in both Vanilla JS template literals and React JSX components.
+**Learning:** This vulnerability pattern existed because external links were dynamically generated or hardcoded without explicit security attributes, potentially allowing the newly opened tab to manipulate the original tab's `window.opener` object.
+**Prevention:** Always include `rel="noopener noreferrer"` on any `<a>` tag that uses `target="_blank"`.

--- a/js/app.js
+++ b/js/app.js
@@ -275,8 +275,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -342,8 +342,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** External links using `target="_blank"` lacked the `rel="noopener noreferrer"` attribute. This allows the newly opened page to access the original page's `window.opener` object, potentially leading to malicious manipulation (reverse tabnabbing).
🎯 **Impact:** If an external link is compromised or redirects to a malicious site, it could potentially manipulate the portfolio page, leading to a phishing attack or unauthorized actions.
🔧 **Fix:** Added `rel="noopener noreferrer"` to all four instances of `target="_blank"` across `js/app.js`, `scouter/RankInsignia.jsx`, and `scouter/HeroLockOn.jsx`.
✅ **Verification:** Verified via an automated Python script (`verify.py`) that all `target="_blank"` links in the codebase correctly implement `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [5865054345818812607](https://jules.google.com/task/5865054345818812607) started by @VBSylvain*