### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Reverse Tabnabbing Vulnerability]
+**Vulnerability:** External links with `target="_blank"` without `rel="noopener noreferrer"`.
+**Learning:** This exposes the application to reverse tabnabbing attacks, where the opened tab can gain a reference to the original window (via `window.opener`) and potentially redirect it to a malicious site.
+**Prevention:** Always add `rel="noopener noreferrer"` to external links using `target="_blank"`.

--- a/js/app.js
+++ b/js/app.js
@@ -275,8 +275,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -342,8 +342,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
Added `rel="noopener noreferrer"` to external links using `target="_blank"` to prevent reverse tabnabbing via `window.opener`. This affects the standard portfolio theme and the scouter theme.

---
*PR created automatically by Jules for task [893398017259152303](https://jules.google.com/task/893398017259152303) started by @VBSylvain*