### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing in external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-08 - Prevent Reverse Tabnabbing
+**Vulnerability:** External links with `target="_blank"` missing the `rel="noopener noreferrer"` attributes, specifically in dynamically generated JS and React JSX files.
+**Learning:** Found multiple instances where external links were missing these critical security attributes. When an external page is opened via `target="_blank"` without `noopener noreferrer`, the newly opened tab gains access to the original window's `window.opener` object. This can lead to a reverse tabnabbing attack where the external page redirects the original page to a malicious phishing site.
+**Prevention:** Ensure all external links utilizing `target="_blank"` explicitly include `rel="noopener noreferrer"`.

--- a/js/app.js
+++ b/js/app.js
@@ -275,8 +275,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -342,8 +342,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Reverse Tabnabbing and Referrer Leakage. External links utilizing `target="_blank"` without the `rel="noopener noreferrer"` attributes were found in dynamic JS and JSX files. When an external page is opened this way, the newly opened tab gains access to the original window's `window.opener` object, which can be exploited to redirect the original page to a malicious site.
🎯 **Impact:** An attacker could potentially replace the portfolio page with a phishing site in the original tab after a user clicks an external link (like LinkedIn or Malt), compromising user trust and security. It also unnecessarily leaked the referring URL.
🔧 **Fix:** Added `rel="noopener noreferrer"` to all 8 instances of `target="_blank"` anchor tags across `js/app.js`, `scouter/RankInsignia.jsx`, and `scouter/HeroLockOn.jsx`.
✅ **Verification:** Verified via `grep` that all instances of `target="_blank"` now include the appropriate `rel` attributes. Evaluated successfully via code review. Evaluated learning patterns and stored them in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3273227391587814322](https://jules.google.com/task/3273227391587814322) started by @VBSylvain*