### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-12 - [Reverse Tabnabbing Vulnerability in Dynamically Injected Links]
+**Vulnerability:** External links generated dynamically using template literals in `js/app.js` (and also in `scouter/RankInsignia.jsx` and `scouter/HeroLockOn.jsx`) use `target="_blank"` but do not include `rel="noopener noreferrer"`. Some have only `rel="noopener"`.
+**Learning:** This exposes the application to reverse tabnabbing, where the newly opened tab can gain access to the `window.opener` object of the original page and potentially redirect it to a malicious site. Even when dynamically rendered via JS, this attribute is critical for security.
+**Prevention:** Always add `rel="noopener noreferrer"` to any anchor tag that uses `target="_blank"`, especially those injected directly into the DOM.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Reverse Tabnabbing (Missing `rel="noopener noreferrer"` on `target="_blank"` links)
🎯 Impact: A malicious newly opened site could gain access to the `window.opener` object and redirect the original page.
🔧 Fix: Added `rel="noopener noreferrer"` to all anchor tags with `target="_blank"` in `js/app.js`, `scouter/RankInsignia.jsx`, and `scouter/HeroLockOn.jsx`.
✅ Verification: Ran a custom python script verifying that all matching tags have the correct `rel` attribute.

---
*PR created automatically by Jules for task [294929570303704404](https://jules.google.com/task/294929570303704404) started by @VBSylvain*