### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-30 - [Reverse Tabnabbing Risk in External Links]
+**Vulnerability:** External links (`<a target="_blank">`) do not include `rel="noopener noreferrer"`. This exposes the site to reverse tabnabbing, allowing the newly opened tab to manipulate the `window.opener` object and potentially redirect the original page to a malicious site.
+**Learning:** This is a common oversight in static websites or vanilla JavaScript apps rendering HTML dynamically (e.g., via template literals). It needs to be consistently applied to all external links.
+**Prevention:** Ensure that all anchor tags with `target="_blank"` include `rel="noopener noreferrer"`. Incorporate this check into a linting process or manually verify during code reviews.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links utilizing `target="_blank"` did not include `rel="noopener noreferrer"`.
🎯 Impact: This exposes the application to reverse tabnabbing. The newly opened tab can manipulate the `window.opener` object, potentially redirecting the original page to a malicious site.
🔧 Fix: Added `rel="noopener noreferrer"` to all anchor tags with `target="_blank"` in js/app.js.
✅ Verification: Ran a custom python script to verify no `target="_blank"` tags exist without `rel="noopener noreferrer"`.

---
*PR created automatically by Jules for task [12260273176400197259](https://jules.google.com/task/12260273176400197259) started by @VBSylvain*