### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing rel noopener noreferrer to external links

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links opening in new tabs (target="_blank") are missing the `rel="noopener noreferrer"` attribute.
🎯 Impact: Reverse tabnabbing vulnerability, allowing the newly opened tab to potentially exploit the `window.opener` object and redirect the original page to a malicious site.
🔧 Fix: Added `rel="noopener noreferrer"` to all external links in `js/app.js`.
✅ Verification: The codebase was inspected to ensure all dynamically injected links use this security measure.

---
*PR created automatically by Jules for task [17868187845945657348](https://jules.google.com/task/17868187845945657348) started by @VBSylvain*