### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability in external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-30 - Fix Reverse Tabnabbing
+**Vulnerability:** Missing `rel="noopener noreferrer"` in `target="_blank"` anchor links.
+**Learning:** External links missing `noopener` expose `window.opener` object, leading to potential phishing redirects by maliciously modifying the original opener window.
+**Prevention:** Ensure that all dynamically generated anchors using `target="_blank"` explicitly include `rel="noopener noreferrer"`.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,9 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Added rel="noopener noreferrer" to prevent reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +345,9 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <!-- 🛡️ Sentinel: Added rel="noopener noreferrer" to prevent reverse tabnabbing -->
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: HIGH\n💡 Vulnerability: Missing rel="noopener noreferrer" on target="_blank" links (Reverse Tabnabbing)\n🎯 Impact: An attacker could potentially gain access to the window.opener object and redirect the original page to a malicious site.\n🔧 Fix: Added rel="noopener noreferrer" to all external links in js/app.js.\n✅ Verification: Verify that the generated links now include the rel attribute.

---
*PR created automatically by Jules for task [4876072506309333780](https://jules.google.com/task/4876072506309333780) started by @VBSylvain*