### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-08-09 - [Missing Reverse Tabnabbing Protection]
+**Vulnerability:** External links utilizing `target="_blank"` in `js/app.js` do not include `rel="noopener noreferrer"`.
+**Learning:** This exposes the application to reverse tabnabbing, allowing the new tab to manipulate the window.opener object and potentially redirect the original tab to a malicious site.
+**Prevention:** Always include `rel="noopener noreferrer"` when using `target="_blank"` for external links.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links utilizing `target="_blank"` did not include `rel="noopener noreferrer"`.
🎯 Impact: This exposes the application to reverse tabnabbing, allowing the new tab to manipulate the window.opener object and potentially redirect the original tab to a malicious site.
🔧 Fix: Added `rel="noopener noreferrer"` to all external links in `js/app.js` using `target="_blank"`.
✅ Verification: Run `git diff` to ensure `rel="noopener noreferrer"` is present on all modified `target="_blank"` links.

---
*PR created automatically by Jules for task [16892050412806103335](https://jules.google.com/task/16892050412806103335) started by @VBSylvain*