### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Reverse Tabnabbing Vulnerability
+**Vulnerability:** External links (`<a target="_blank">`) were missing `rel="noopener noreferrer"`.
+**Learning:** This is a common issue when dynamically creating DOM elements with template literals. Without these attributes, the new tab has a reference to `window.opener` and can navigate the original tab to a malicious site. Even when `rel="noopener"` is partially applied (as in some components), the best practice includes `noreferrer` for wider protection.
+**Prevention:** Use an AST or automated linter for React (eslint-plugin-react) and review DOM templates explicitly for the `target="_blank"` pattern, ensuring it is always paired with `rel="noopener noreferrer"`.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: External links with target=_blank were missing rel=noopener noreferrer, allowing potential reverse tabnabbing attacks.
🎯 Impact: Malicious external sites could potentially gain reference to window.opener and navigate the user to a phishing page.
🔧 Fix: Added rel=noopener noreferrer to all target=_blank anchor tags.
✅ Verification: Verified locally via code inspection.

---
*PR created automatically by Jules for task [13192214613743908626](https://jules.google.com/task/13192214613743908626) started by @VBSylvain*