### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-08-13 - [Reverse Tabnabbing]
+**Vulnerability:** Reverse tabnabbing vulnerability via `target="_blank"` without `rel="noopener noreferrer"`.
+**Learning:** External links utilizing `target="_blank"` without explicit `rel="noopener noreferrer"` can allow malicious sites to hijack the `window.opener` reference, leading to potential reverse tabnabbing and phishing.
+**Prevention:** All external links utilizing `target="_blank"` must explicitly include `rel="noopener noreferrer"`.

--- a/js/app.js
+++ b/js/app.js
@@ -277,8 +277,8 @@ function renderHero() {
             `).join('')}
         </div>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }
@@ -344,8 +344,8 @@ function renderContact() {
         <h2 data-i18n="contact_title">${translations[lang].contact_title}</h2>
         <p class="contact-msg">${contact[`message_${lang}`]}</p>
         <div class="hero-actions">
-            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank">LinkedIn</a>
-            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank">Malt</a>
+            <a href="${contact.linkedin_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            <a href="${contact.malt_url || '#'}" class="btn btn-primary" target="_blank" rel="noopener noreferrer">Malt</a>
         </div>
     `;
 }

--- a/scouter/HeroLockOn.jsx
+++ b/scouter/HeroLockOn.jsx
@@ -22,10 +22,10 @@ function HeroLockOn({ identity, heroStats, lang, battleMode, onToggleBattle, toP
         <p className="tagline">{identity[`tagline_${lang}`]}</p>
 
         <div className="btn-row">
-          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn primary" href="https://www.linkedin.com/in/vbsylvain" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · LINKEDIN
           </a>
-          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener" onMouseEnter={sfx}>
+          <a className="btn" href="https://www.malt.fr/profile/sylvainvizzinibruyas" target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>
             UPLINK · MALT
           </a>
         </div>

--- a/scouter/RankInsignia.jsx
+++ b/scouter/RankInsignia.jsx
@@ -23,8 +23,8 @@ function ContactBeacon({ contact, lang }) {
       <h2>{lang === 'fr' ? 'OUVRIR LE CANAL' : 'OPEN CHANNEL'}</h2>
       <p>{contact[`message_${lang}`]}</p>
       <div className="btn-row">
-        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
-        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener" onMouseEnter={sfx}>UPLINK · MALT</a>
+        <a className="btn primary" href={contact.linkedin_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · LINKEDIN</a>
+        <a className="btn" href={contact.malt_url} target="_blank" rel="noopener noreferrer" onMouseEnter={sfx}>UPLINK · MALT</a>
       </div>
     </section>
   );


### PR DESCRIPTION
🚨 Severity: MEDIUM\n💡 Vulnerability: Reverse tabnabbing vulnerability via `target="_blank"` links.\n🎯 Impact: Malicious sites could take control of the original window and navigate it to a phishing site.\n🔧 Fix: Added `rel="noopener noreferrer"` to all `target="_blank"` links.\n✅ Verification: Checked manually and via python script that all links have the proper attribute.

---
*PR created automatically by Jules for task [9814035662847269873](https://jules.google.com/task/9814035662847269873) started by @VBSylvain*